### PR TITLE
Adds Helper Functions to De/Encode fixed-width Integers

### DIFF
--- a/ztype/bits_decode.go
+++ b/ztype/bits_decode.go
@@ -23,3 +23,51 @@ func ReadSignedBits(r *bitio.CountReader, bits uint8) (int64, error) {
 	}
 	return int64(u), nil
 }
+
+// ReadUint8 reads an unsigned 8-bit integer.
+func ReadUint8(r *bitio.CountReader) (uint8, error) {
+	value, err := ReadUnsignedBits(r, 8)
+	return uint8(value), err
+}
+
+// ReadUint16 reads an unsigned 16-bit integer.
+func ReadUint16(r *bitio.CountReader) (uint16, error) {
+	value, err := ReadUnsignedBits(r, 16)
+	return uint16(value), err
+}
+
+// ReadUint32 reads an unsigned 32-bit integer.
+func ReadUint32(r *bitio.CountReader) (uint32, error) {
+	value, err := ReadUnsignedBits(r, 32)
+	return uint32(value), err
+}
+
+// ReadUint64 reads an unsigned 64-bit integer.
+func ReadUint64(r *bitio.CountReader) (uint64, error) {
+	value, err := ReadUnsignedBits(r, 64)
+	return uint64(value), err
+}
+
+// ReadInt8 reads a signed 8-bit integer.
+func ReadInt8(r *bitio.CountReader) (int8, error) {
+	value, err := ReadSignedBits(r, 8)
+	return int8(value), err
+}
+
+// ReadInt16 reads a signed 16-bit integer.
+func ReadInt16(r *bitio.CountReader) (int16, error) {
+	value, err := ReadSignedBits(r, 16)
+	return int16(value), err
+}
+
+// ReadInt32 reads a signed 32-bit integer.
+func ReadInt32(r *bitio.CountReader) (int32, error) {
+	value, err := ReadSignedBits(r, 32)
+	return int32(value), err
+}
+
+// ReadInt64 reads a signed 64-bit integer.
+func ReadInt64(r *bitio.CountReader) (int64, error) {
+	value, err := ReadSignedBits(r, 64)
+	return int64(value), err
+}

--- a/ztype/bits_encode.go
+++ b/ztype/bits_encode.go
@@ -34,3 +34,43 @@ func WriteSignedBits(w *bitio.CountWriter, value int64, bits uint8) error {
 	var v uint64 = (1 << bits) | uint64(value+(1<<bits))
 	return w.WriteBits(v, bits)
 }
+
+// WriteUint8 writes an unsigned 8-bit integer.
+func WriteUint8(w *bitio.CountWriter, value uint8) error {
+	return WriteUnsignedBits(w, uint64(value), 8)
+}
+
+// WriteUint16 writes an unsigned 16-bit integer.
+func WriteUint16(w *bitio.CountWriter, value uint16) error {
+	return WriteUnsignedBits(w, uint64(value), 16)
+}
+
+// WriteUint32 writes an unsigned 32-bit integer.
+func WriteUint32(w *bitio.CountWriter, value uint32) error {
+	return WriteUnsignedBits(w, uint64(value), 32)
+}
+
+// WriteUint64 writes an unsigned 64-bit integer.
+func WriteUint64(w *bitio.CountWriter, value uint64) error {
+	return WriteUnsignedBits(w, uint64(value), 64)
+}
+
+// WriteInt8 writes a signed 8-bit integer.
+func WriteInt8(w *bitio.CountWriter, value int8) error {
+	return WriteSignedBits(w, int64(value), 8)
+}
+
+// WriteInt16 writes a signed 16-bit integer.
+func WriteInt16(w *bitio.CountWriter, value int16) error {
+	return WriteSignedBits(w, int64(value), 16)
+}
+
+// WriteInt32 writes a signed 32-bit integer.
+func WriteInt32(w *bitio.CountWriter, value int32) error {
+	return WriteSignedBits(w, int64(value), 32)
+}
+
+// WriteInt64 writes a signed 64-bit integer.
+func WriteInt64(w *bitio.CountWriter, value int64) error {
+	return WriteSignedBits(w, int64(value), 64)
+}


### PR DESCRIPTION
- These helper functions are useful to make the generated code more
  readable.