### PR TITLE
Adds a helper function "TryUnsignedBitSize()"

### DIFF
--- a/ztype/varuint_encode.go
+++ b/ztype/varuint_encode.go
@@ -58,6 +58,14 @@ func writeVarUint(w *bitio.CountWriter, v uint64, maxBytes int) error {
 	return w.TryError
 }
 
+// TryUnsignedBitSize is a simplified version of UnsignedBitSize(), that is
+// needed for use within expressions. Within an expression, there is no possibility
+// for error checking or branching.
+func TryUnsignedBitSize(v uint64) int {
+	value, _ := UnsignedBitSize(v, 64)
+	return value
+}
+
 // UnsignedBitSize returns the size in bits of the zserio encoding of an unsigned
 // value. Unlike the Python zserio version this version is generic and does
 // not need a per-type table, but still gets identical performance.


### PR DESCRIPTION
- This function is basically the same as UnsignedBitSize(), but
  only returns the value, not the error code.
- This is needed for expression generation, that usually write the
  code as one-liners.
- Expression generation currently does not support branching.