### PR TITLE
Refactor the Object and Packed Object Array Traits

### DIFF
--- a/interface/iface.go
+++ b/interface/iface.go
@@ -20,6 +20,7 @@ type Marshaler interface {
 type ZserioType interface {
 	Marshaler
 	Unmarshaler
+	Clone() ZserioType
 }
 
 type PackableUnmarshaler interface {

--- a/internal/generator/templates/array_init.go.tmpl
+++ b/internal/generator/templates/array_init.go.tmpl
@@ -1,6 +1,8 @@
 {{ $scope := .pkg }}
 {{ $field_name := .field_name }}
 {{ $array := .array }}
+{{ $type := .type }}
+{{- $traits := goArrayTraits $scope $type }}
 {{- if $array.IsPacked }}
     {{ $field_name }}.IsPacked = true
 {{- end }}
@@ -8,4 +10,7 @@
     {{ $field_name }}.FixedSize = int({{ goExpression $scope $array.Length }})
 {{- else }}
     {{ $field_name }}.IsAuto = true
+{{- end }}
+{{- if eq $traits "ztype.ObjectArrayTraits" }}
+    {{ $field_name }}.ArrayTraits.DefaultObject = new({{ goType $scope $type }})
 {{- end }}

--- a/internal/generator/templates/array_traits_type.go.tmpl
+++ b/internal/generator/templates/array_traits_type.go.tmpl
@@ -3,4 +3,4 @@
 {{- $traits := goArrayTraits $scope $type }}
 {{- $traits }}
 {{- if eq $traits "ztype.BitFieldArrayTraits" }}[{{ goType $scope $type }}]{{- end -}}
-{{- if eq $traits "ztype.ObjectArrayTraits" }}[{{ goType $scope $type }}, *{{ goType $scope $type }}]{{- end -}}
+{{- if eq $traits "ztype.ObjectArrayTraits" }}[*{{ goType $scope $type }}]{{- end -}}

--- a/internal/generator/templates/bitmask.go.tmpl
+++ b/internal/generator/templates/bitmask.go.tmpl
@@ -17,6 +17,11 @@ const (
 {{- end }}
 )
 
+func (v *{{ $bitmask.Name}}) Clone() zserio.ZserioType {
+  clone := *v
+  return &clone
+}
+
 func (v *{{ $bitmask.Name}}) LoadDefaultValues() error {
   return nil
 }

--- a/internal/generator/templates/choice.go.tmpl
+++ b/internal/generator/templates/choice.go.tmpl
@@ -14,6 +14,12 @@ type {{ $choice.Name }} struct {
 {{- end }}
 }
 
+func (v *{{ $choice.Name}}) Clone() zserio.ZserioType {
+  clone := &{{ $choice.Name }}{}
+  *clone = *v
+  return clone
+}
+
 func (v *{{ $choice.Name}}) LoadDefaultValues() error {
 {{- range $case := $choice.Cases }}
   {{- if .Field }}

--- a/internal/generator/templates/decode.go.tmpl
+++ b/internal/generator/templates/decode.go.tmpl
@@ -36,7 +36,7 @@
     } else if present {
 
     {{- if $field.Array }}
-        var value ztype.Array[{{if $native.IsMarshaler }}*{{ end }}{{ goType $scope $field.Type -}}, {{ template "array_traits_type.go.tmpl" dict "pkg" $scope "type" $field.Type }}]
+        var value ztype.Array[{{if $native.IsMarshaler }}*{{ end }}{{ goType $scope $native.Type -}}, {{ template "array_traits_type.go.tmpl" dict "pkg" $scope "type" $native.Type }}]
     {{- else }}
         var value {{ goType $scope $field.Type }}
     {{- end }}
@@ -55,10 +55,10 @@
         return err
     }
 {{- else}}
-    {{- template "decode_compound_parameters.go.tmpl" dict "pkg" $scope "field" $field }}
     {{- if $field.Array }}
-        {{- template "array_init.go.tmpl" dict "pkg" $scope "field_name" $assign_str_lvalue "array" $field.Array }}
+        {{- template "array_init.go.tmpl" dict "pkg" $scope "field_name" $assign_str_lvalue "array" $field.Array "type" $native.Type }}
     {{- end }}
+    {{- template "decode_compound_parameters.go.tmpl" dict "pkg" $scope "field" $field }}
     if err = {{ $assign_str_rvalue }}.UnmarshalZserio(r); err != nil {
         return err
     }

--- a/internal/generator/templates/encode.go.tmpl
+++ b/internal/generator/templates/encode.go.tmpl
@@ -37,7 +37,7 @@
 {{- end }}
 {{- template "encode_compound_parameters.go.tmpl" dict "pkg" $scope "field" $field }}
 {{- if $field.Array }}
-    {{- template "encode_array_init.go.tmpl" dict "pkg" $scope "field_name" $field_name "array" $field.Array }}
+    {{- template "encode_array_init.go.tmpl" dict "pkg" $scope "field_name" $field_name "array" $field.Array "type" $native.Type }}
 {{- end }}
 {{- if and (not $native.IsMarshaler) (not $field.Array) }}
     {{- if or (gt $native.Type.Bits 0) $native.Type.LengthExpression}}

--- a/internal/generator/templates/enum.go.tmpl
+++ b/internal/generator/templates/enum.go.tmpl
@@ -17,6 +17,11 @@ const (
 {{- end }}
 )
 
+func (v *{{ $enum.Name}}) Clone() zserio.ZserioType {
+  clone := *v
+  return &clone
+}
+
 func (v *{{ $enum.Name}}) LoadDefaultValues() error {
   return nil
 }

--- a/internal/generator/templates/packing_context_decode.go.tmpl
+++ b/internal/generator/templates/packing_context_decode.go.tmpl
@@ -35,10 +35,13 @@
     {{- $assign_str_lvalue := printf "v.%s" $field.Name }}
     {{- $assign_str_rvalue := $field_name }}
 
+    {{- if $field.Array }}
+    {{- template "array_init.go.tmpl" dict "pkg" $scope "field_name" $assign_str_lvalue "array" $field.Array "type" $native.Type }}
+    {{- end }}
+    
     {{- template "decode_compound_parameters.go.tmpl" dict "pkg" $scope "field" $field }}
 
     {{- if $field.Array }}
-        {{- template "array_init.go.tmpl" dict "pkg" $scope "field_name" $assign_str_lvalue "array" $field.Array }}
         {{- if not $field.Array.IsPacked }}
             // This array is implicitly packed, because its parent object is packed
             {{ $assign_str_rvalue }}.IsPacked = true

--- a/internal/generator/templates/packing_context_encode.go.tmpl
+++ b/internal/generator/templates/packing_context_encode.go.tmpl
@@ -36,11 +36,14 @@
     {{- end }}
 
     {{- $read_str_lvalue := $field_name }}
+    
+    {{- if $field.Array }}
+        {{- template "encode_array_init.go.tmpl" dict "pkg" $scope "field_name" $read_str_lvalue "array" $field.Array "type" $native.Type }}
+    {{- end }}
 
     {{- template "encode_compound_parameters.go.tmpl" dict "pkg" $scope "field" $field }}
     
     {{- if $field.Array }}
-        {{- template "encode_array_init.go.tmpl" dict "pkg" $scope "field_name" $read_str_lvalue "array" $field.Array }}
         {{- if not $field.Array.IsPacked }}
             // This array is implicitly packed, because its parent object is packed
             {{ $read_str_lvalue }}.IsPacked = true

--- a/internal/generator/templates/struct.go.tmpl
+++ b/internal/generator/templates/struct.go.tmpl
@@ -12,6 +12,12 @@ type {{ $struct.Name }} struct {
 {{- end }}
 }
 
+func (v *{{ $struct.Name}}) Clone() zserio.ZserioType {
+  clone := &{{ $struct.Name }}{}
+  *clone = *v
+  return clone
+}
+
 func (v *{{ $struct.Name}}) LoadDefaultValues() error {
 {{- range $field := $struct.Fields }}
 {{template "default_values.go.tmpl" dict "pkg" $scope "field" $field }}

--- a/internal/generator/templates/union.go.tmpl
+++ b/internal/generator/templates/union.go.tmpl
@@ -25,6 +25,12 @@ UnionChoice {{ $union.Name }}UnionChoiceType
 {{- end }}
 }
 
+func (v *{{ $union.Name}}) Clone() zserio.ZserioType {
+  clone := &{{ $union.Name }}{}
+  *clone = *v
+  return clone
+}
+
 func (v *{{ $union.Name}}) LoadDefaultValues() error {
 {{- range $field := $union.Fields }}
   {{template "default_values.go.tmpl" dict "pkg" $scope "field" $field }}

--- a/ztype/array_traits.go
+++ b/ztype/array_traits.go
@@ -609,61 +609,55 @@ func (trait StringArrayTraits) FromUint64(value uint64) string {
 	return "" // not supported for string objects
 }
 
-// ObjectArrayTraitsType is an interface type which points to a zserioType, and must not be an interface.
-type ObjectArrayTraitsType[B any] interface {
-	zserio.PackableZserioType
-	*B // non-interface type constraint element
-}
-
 // ObjectArrayTraits is an array traits for zserio structs, choice, union or enum types
-type ObjectArrayTraits[T any, PT ObjectArrayTraitsType[T]] struct {
+type ObjectArrayTraits[T zserio.PackableZserioType] struct {
 	DefaultObject T
 }
 
-func (trait ObjectArrayTraits[T, PT]) PackedTraits() IPackedArrayTraits[PT] {
-	return &ObjectPackedArrayTraits[T, PT, ObjectArrayTraits[T, PT]]{
+func (trait ObjectArrayTraits[T]) PackedTraits() IPackedArrayTraits[T] {
+	return &ObjectPackedArrayTraits[T, ObjectArrayTraits[T]]{
 		ArrayTraits:   trait,
 		DefaultObject: trait.DefaultObject,
 	}
 }
 
-func (trait ObjectArrayTraits[T, PT]) BitSizeOfIsConstant() bool {
+func (trait ObjectArrayTraits[T]) BitSizeOfIsConstant() bool {
 	return false
 }
 
-func (trait ObjectArrayTraits[T, PT]) NeedsBitsizeOfPosition() bool {
+func (trait ObjectArrayTraits[T]) NeedsBitsizeOfPosition() bool {
 	return true
 }
 
-func (trait ObjectArrayTraits[T, PT]) NeedsReadIndex() bool {
+func (trait ObjectArrayTraits[T]) NeedsReadIndex() bool {
 	return true
 }
 
-func (trait ObjectArrayTraits[T, PT]) BitSizeOf(element PT, endBitPosition int) int {
+func (trait ObjectArrayTraits[T]) BitSizeOf(element T, endBitPosition int) int {
 	bitSize, _ := element.ZserioBitSize(endBitPosition)
 	return bitSize
 }
 
-func (trait ObjectArrayTraits[T, PT]) InitializeOffsets(bitPosition int, value PT) int {
-	offset := 0 // , _ := value.InitializeOffsets(bitPosition)
+func (trait ObjectArrayTraits[T]) InitializeOffsets(bitPosition int, value T) int {
+	offset := 0
 	return offset
 }
 
-func (trait ObjectArrayTraits[T, PT]) Read(reader *bitio.CountReader, endBitPosition int) (PT, error) {
-	value := PT(new(T))
-	*value = trait.DefaultObject
+func (trait ObjectArrayTraits[T]) Read(reader *bitio.CountReader, endBitPosition int) (T, error) {
+	value := trait.DefaultObject.Clone().(T)
 	err := value.UnmarshalZserio(reader)
 	return value, err
 }
 
-func (trait ObjectArrayTraits[T, PT]) Write(writer *bitio.CountWriter, value PT) error {
+func (trait ObjectArrayTraits[T]) Write(writer *bitio.CountWriter, value T) error {
 	return value.MarshalZserio(writer)
 }
 
-func (trait ObjectArrayTraits[T, PT]) AsUint64(value PT) uint64 {
+func (trait ObjectArrayTraits[T]) AsUint64(value T) uint64 {
 	return 0 // not supported
 }
 
-func (trait ObjectArrayTraits[T, PT]) FromUint64(value uint64) PT {
-	return nil // not supported
+func (trait ObjectArrayTraits[T]) FromUint64(value uint64) T {
+	var dummy T
+	return dummy // not supported
 }


### PR DESCRIPTION
- The current method if object array traits (using two template parameters)
  doesn't work: it fails when an array of the object type is instantiated
  inside the object, for example:

```
struct A {
   array ztype.Array[*A, ztype.ObjectArrayTraits[A, *A]]
}
```

  This will not compile because of the non-pointer access to A inside the
  array traits. Therefore, this approach was scrapped.
- The approach with the two template parameter was chosen to be able to
  instantiate an array element during array decoding. Therefore, a new
  way of instantiation new array elements must be found.
- A factory function, e.g. NewLaneCenterLine() would be nice, but doesn't
  work with generic names.
- The solution was to implement a Clone() function for each zserio object,
  which creates a copy of the default value object within the array.