### PR TITLE
Add Casts to Integer Types when Comparison or Arithmetic Operators ar…

### DIFF
--- a/internal/ast/expression.go
+++ b/internal/ast/expression.go
@@ -264,6 +264,9 @@ func (expr *Expression) evaluateFunctionCallExpression(scope *Package) error {
 		return err
 	}
 	copyExpressionResult(function.Result, expr)
+	// copy the result symbol, in case the type of the symbol needs to be
+	// evaluated.
+	expr.ResultSymbol = expr.Operand1.ResultSymbol
 	return nil
 }
 


### PR DESCRIPTION
…e used

- Unlike C++ or Python, Go complains if you try to implicitly cast
  integer types. That means that some of the generated code will
  not compile under go, because typecasts are missing.
- The code generation was changed to verify that in case of a
  arithmetic or comparison expression is used, and the operands
  are integer types, then the generator code checks if the types differ,
  and adds a type cast if needed.