### PR TITLE
Initialize Array Traits during Encoding

### DIFF
--- a/internal/generator/templates/array_init.go.tmpl
+++ b/internal/generator/templates/array_init.go.tmpl
@@ -3,6 +3,8 @@
 {{ $array := .array }}
 {{ $type := .type }}
 {{- $traits := goArrayTraits $scope $type }}
+
+{{- $field_name }}.ArrayTraits = {{ template "instantiate_array_traits.go.tmpl" dict "pkg" $scope "type" $type }}
 {{- if $array.IsPacked }}
     {{ $field_name }}.IsPacked = true
 {{- end }}

--- a/internal/generator/templates/bitmask.go.tmpl
+++ b/internal/generator/templates/bitmask.go.tmpl
@@ -88,7 +88,7 @@ func (v *{{ $bitmask.Name}}) UnmarshalZserioPacked(contextNode *zserio.PackingCo
   if !ok {
     return errors.New("unsupported packing context type")
   }
-  if tempValue, err := context.Read(&{{- template "instantiate_array_traits.go.tmpl" dict "pkg" $scope "native" $native }}, r); err != nil {
+  if tempValue, err := context.Read(&{{- template "instantiate_array_traits.go.tmpl" dict "pkg" $scope "type" $native.Type }}, r); err != nil {
     return err
   } else {
     (*v) = {{ $bitmask.Name }}(tempValue)
@@ -101,7 +101,7 @@ func (v *{{ $bitmask.Name}}) MarshalZserioPacked(contextNode *zserio.PackingCont
   if !ok {
     return errors.New("unsupported packing context type")
   }
-  return context.Write(&{{- template "instantiate_array_traits.go.tmpl" dict "pkg" $scope "native" $native }}, w, {{ goType $scope $native.Type }}(*v))
+  return context.Write(&{{- template "instantiate_array_traits.go.tmpl" dict "pkg" $scope "type" $native.Type }}, w, {{ goType $scope $native.Type }}(*v))
 }
 
 func (v *{{ $bitmask.Name}}) ZserioInitializeOffsetsPacked(contextNode *zserio.PackingContextNode, bitPosition int) int {

--- a/internal/generator/templates/encode_array_init.go.tmpl
+++ b/internal/generator/templates/encode_array_init.go.tmpl
@@ -1,6 +1,8 @@
 {{ $scope := .pkg }}
 {{ $field_name := .field_name }}
 {{ $array := .array }}
+{{ $type := .type }}
+{{- $field_name }}.ArrayTraits = {{ template "instantiate_array_traits.go.tmpl" dict "pkg" $scope "type" $type }}
 {{- if $array.IsPacked }}
     {{ $field_name }}.IsPacked = true
 {{- end }}

--- a/internal/generator/templates/enum.go.tmpl
+++ b/internal/generator/templates/enum.go.tmpl
@@ -86,7 +86,7 @@ func (v *{{ $enum.Name}}) ZserioInitPackingContext(contextNode *zserio.PackingCo
   if !ok {
     return errors.New("unsupported packing context type")
   }
-  context.Init(&{{- template "instantiate_array_traits.go.tmpl" dict "pkg" $scope "native" $native }}, {{ goType $scope $native.Type }}(*v))
+  context.Init(&{{- template "instantiate_array_traits.go.tmpl" dict "pkg" $scope "type" $native.Type }}, {{ goType $scope $native.Type }}(*v))
   return nil
 }
 
@@ -96,7 +96,7 @@ func (v *{{ $enum.Name}}) UnmarshalZserioPacked(contextNode *zserio.PackingConte
   if !ok {
     return errors.New("unsupported packing context type")
   }
-  if tempValue, err := context.Read(&{{- template "instantiate_array_traits.go.tmpl" dict "pkg" $scope "native" $native }}, r); err != nil {
+  if tempValue, err := context.Read(&{{- template "instantiate_array_traits.go.tmpl" dict "pkg" $scope "type" $native.Type }}, r); err != nil {
     return err
   } else {
     (*v) = {{ $enum.Name }}(tempValue)
@@ -109,7 +109,7 @@ func (v *{{ $enum.Name}}) MarshalZserioPacked(contextNode *zserio.PackingContext
   if !ok {
     return errors.New("unsupported packing context type")
   }
-  return context.Write(&{{- template "instantiate_array_traits.go.tmpl" dict "pkg" $scope "native" $native }}, w, {{ goType $scope $native.Type }}(*v))
+  return context.Write(&{{- template "instantiate_array_traits.go.tmpl" dict "pkg" $scope "type" $native.Type }}, w, {{ goType $scope $native.Type }}(*v))
 }
 
 func (v *{{ $enum.Name}}) ZserioInitializeOffsetsPacked(contextNode *zserio.PackingContextNode, bitPosition int) int {

--- a/internal/generator/templates/instantiate_array_traits.go.tmpl
+++ b/internal/generator/templates/instantiate_array_traits.go.tmpl
@@ -1,21 +1,21 @@
 {{- $scope := .pkg }}
-{{- $native := .native }}
-{{- $traits := goArrayTraits $scope $native.Type }}
-{{- template "array_traits_type.go.tmpl" dict "pkg" $scope "type" $native.Type }} {
+{{- $type := .type }}
+{{- $traits := goArrayTraits $scope $type }}
+{{- template "array_traits_type.go.tmpl" dict "pkg" $scope "type" $type }} {
 {{- if eq $traits "ztype.BitFieldArrayTraits" -}}
     NumBits: uint8(
-    {{- if gt $native.Type.Bits 0 }}
-        {{- $native.Type.Bits }}
-    {{- else if $native.Type.LengthExpression }}
-        {{- goExpression $scope $native.Type.LengthExpression }}
-    {{- else if eq $native.Type.Name "uint8" }}8
-    {{- else if eq $native.Type.Name "uint16" }}16
-    {{- else if eq $native.Type.Name "uint32" }}32
-    {{- else if eq $native.Type.Name "uint64" }}64
-    {{- else if eq $native.Type.Name "int8" }}8
-    {{- else if eq $native.Type.Name "int16" }}16
-    {{- else if eq $native.Type.Name "int32" }}32
-    {{- else if eq $native.Type.Name "int64" }}64
+    {{- if gt $type.Bits 0 }}
+        {{- $type.Bits }}
+    {{- else if $type.LengthExpression }}
+        {{- goExpression $scope $type.LengthExpression }}
+    {{- else if eq $type.Name "uint8" }}8
+    {{- else if eq $type.Name "uint16" }}16
+    {{- else if eq $type.Name "uint32" }}32
+    {{- else if eq $type.Name "uint64" }}64
+    {{- else if eq $type.Name "int8" }}8
+    {{- else if eq $type.Name "int16" }}16
+    {{- else if eq $type.Name "int32" }}32
+    {{- else if eq $type.Name "int64" }}64
     {{- else }}UNSUPPORTED
     {{- end }})
 {{- end -}}

--- a/internal/generator/templates/packing_context_bitsize.go.tmpl
+++ b/internal/generator/templates/packing_context_bitsize.go.tmpl
@@ -51,7 +51,7 @@
     if field{{ $field.Name }}Context, ok := childrenNodes[{{ $index }}].Context.(*ztype.DeltaContext[{{ goType $scope $native.Type }}]); !ok {
         return 0, errors.New("invalid packing context")
     } else {
-        if delta, err := field{{ $field.Name }}Context.BitSizeOf(&{{ template "instantiate_array_traits.go.tmpl" dict "pkg" $scope "native" $native }}, endBitPosition, {{ goType $scope $native.Type }}({{ $field_name }})); err != nil {
+        if delta, err := field{{ $field.Name }}Context.BitSizeOf(&{{ template "instantiate_array_traits.go.tmpl" dict "pkg" $scope "type" $native.Type }}, endBitPosition, {{ goType $scope $native.Type }}({{ $field_name }})); err != nil {
             return 0, err
         } else {
             endBitPosition += delta

--- a/internal/generator/templates/packing_context_decode.go.tmpl
+++ b/internal/generator/templates/packing_context_decode.go.tmpl
@@ -87,7 +87,7 @@
         if field{{ $field.Name }}Context, ok := childrenNodes[{{ $index }}].Context.(*ztype.DeltaContext[{{ goType $scope $native.Type }}]); !ok {
             return errors.New("unknown context type")
         } else {
-            if tempValue, err := field{{ $field.Name }}Context.Read(&{{ template "instantiate_array_traits.go.tmpl" dict "pkg" $scope "native" $native }}, r); err == nil {
+            if tempValue, err := field{{ $field.Name }}Context.Read(&{{ template "instantiate_array_traits.go.tmpl" dict "pkg" $scope "type" $native.Type }}, r); err == nil {
                 {{ $assign_str_lvalue }} = ({{ goType $scope $field.Type }})(tempValue)
             } else {
                 return err

--- a/internal/generator/templates/packing_context_encode.go.tmpl
+++ b/internal/generator/templates/packing_context_encode.go.tmpl
@@ -77,7 +77,7 @@
         if field{{ $field.Name }}Context, ok := childrenNodes[{{ $index }}].Context.(*ztype.DeltaContext[{{ goType $scope $native.Type }}]); !ok {
             return errors.New("unknown context type")
         } else {
-            if err := field{{ $field.Name }}Context.Write(&{{ template "instantiate_array_traits.go.tmpl" dict "pkg" $scope "native" $native }}, w, {{ goType $scope $native.Type }}({{ $read_str_lvalue }})); err != nil {
+            if err := field{{ $field.Name }}Context.Write(&{{ template "instantiate_array_traits.go.tmpl" dict "pkg" $scope "type" $native.Type }}, w, {{ goType $scope $native.Type }}({{ $read_str_lvalue }})); err != nil {
                 return err
             }
         }

--- a/internal/generator/templates/packing_context_init.go.tmpl
+++ b/internal/generator/templates/packing_context_init.go.tmpl
@@ -32,7 +32,7 @@
         if field{{ $field.Name }}Context, ok := childrenNodes[{{ $index }}].Context.(*ztype.DeltaContext[{{ goType $scope $native.Type }}]); !ok {
             return errors.New("unknown context type")
         } else {
-            field{{ $field.Name }}Context.Init(&{{ template "instantiate_array_traits.go.tmpl" dict "pkg" $scope "native" $native }}, {{ goType $scope $native.Type }}({{ $field_name }}))
+            field{{ $field.Name }}Context.Init(&{{ template "instantiate_array_traits.go.tmpl" dict "pkg" $scope "type" $native.Type }}, {{ goType $scope $native.Type }}({{ $field_name }}))
         }
     {{- end }}
     {{- if $field.OptionalClause }}


### PR DESCRIPTION
- Previously, the array traits were not initialized during Marshaling. The
  array traits had to be manually initialized, or initialized by
  Unmarshaling.
- This lead to hard-to-find errors, because the serialization did not
  raise any warnings or errors, if the traits were not initialized.
- This commit changes this behavior, by implicitly initializing the array
  traits with the correct configuration.