### PR TITLE
Adds a Test Case, Which will Compare Go-Zserio with Reference Zserio

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -2,5 +2,4 @@ load("@bazel_gazelle//:def.bzl", "gazelle")
 
 # gazelle:prefix github.com/woven-planet/go-zserio
 # gazelle:resolve go github.com/antlr/antlr4/runtime/Go/antlr @antlr4_runtimes//:go
-# gazelle:resolve go github.com/woven-planet/go-zserio/test/go-schema/reference_modules/testobject1/testobject //test/go-schema/reference_modules/testobject1/testobject
 gazelle(name = "gazelle")

--- a/test/BUILD.bazel
+++ b/test/BUILD.bazel
@@ -3,21 +3,23 @@ load("@io_bazel_rules_go//go:def.bzl", "go_test")
 genrule(
     name = "testdata",
     outs = ["testdata.bin"],
-    cmd = "$(location //test/python:write_test_data)",
+    cmd = "$(location //test/python:write_test_data) $@",
+    message = "Generating zserio payload binary using official Python bindings",
     tools = ["//test/python:write_test_data"],
 )
 
 go_test(
     name = "test_test",
     srcs = ["integration_test.go"],
-    data = glob([
-        "python/**",
+    data = [
         ":testdata",
-        "features/compare_with_zserio_reference.feature",
-    ]),
+    ] + glob(["features/*.feature"]),
     deps = [
-        "//test/go-schema/reference_modules/testobject1/testobject",
-        "@com_github_cucumber_godog//:go_default_library",
+        "//test/go/reference_modules/testobject1/testobject",
+        "@com_github_cucumber_godog//:godog",
         "@com_github_icza_bitio//:bitio",
     ],
+    env = {
+        "TESTDATA_BIN": "$(rootpath :testdata)",
+    }
 )

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -3,23 +3,31 @@ package go_test
 import (
 	"bytes"
 	"context"
+	"path"
 	"errors"
-	"io"
+	"os"
+	"fmt"
 	"testing"
 
 	"github.com/cucumber/godog"
 	"github.com/icza/bitio"
-	"github.com/woven-planet/go-zserio/test/go-schema/reference_modules/testobject1/testobject"
+	"github.com/woven-planet/go-zserio/test/go/reference_modules/testobject1/testobject"
+)
+
+func testWorkspace(filePath string) string {
+	return path.Join(os.Getenv("TEST_SRCDIR"), os.Getenv("TEST_WORKSPACE"), filePath)
+}
+
+var (
+	// ReferenceFilePath is the path to the input data
+	// TODO @aignas 2022-02-02: use env variables to inject this into the test
+	ReferenceFilePath string = testWorkspace(os.Getenv("TESTDATA_BIN"))
 )
 
 const (
-	// ReferenceFilePath is the path to the input data
-	// TODO @aignas 2022-02-02: use env variables to inject this into the test
-	ReferenceFilePath string = `bin/testdata.bin`
-
 	// ReencodedFilePath is the path where to write the data again
 	// TODO @aignas 2022-02-02: put this into the bazel test directory for undefined outputs
-	ReencodedFilePath string = `bin/testdata_reencoded.bin`
+	ReencodedFilePath string = `testdata_reencoded.bin`
 
 	// TODO @aignas 2022-02-02: can the following constants be injected by bazel?
 	GoZserioOutputDirectory string = `test/go-schema`
@@ -58,7 +66,7 @@ func InitializeScenario(ctx *godog.ScenarioContext) {
 
 func readReferenceZserioFile() error {
 	var err error
-	ReferenceBinaryContent, err = io.ReadFile(ReferenceFilePath)
+	ReferenceBinaryContent, err = os.ReadFile(ReferenceFilePath)
 	if err != nil {
 		return fmt.Errorf("read reference binary: %w", err)
 	}
@@ -83,16 +91,16 @@ func reencodeZserioTestBinary() error {
 		return fmt.Errorf("marshal: %w", err)
 	}
 
-	return io.WriteFile(ReencodedFilePath, buf.Bytes(), 0644)
+	return os.WriteFile(ReencodedFilePath, buf.Bytes(), 0644)
 }
 
 func verifyFilesAreEqual() error {
-	fileA, err := io.ReadFile(ReferenceFilePath)
+	fileA, err := os.ReadFile(ReferenceFilePath)
 	if err != nil {
 		return err
 	}
 
-	fileB, err := io.ReadFile(ReencodedFilePath)
+	fileB, err := os.ReadFile(ReencodedFilePath)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This test case will use reference zserio to generate a binary file,
then decodes the binary data with go-zserio, and encodes it again.
The test will pass if the binary file that gets generated still
matches the original file.