### PR TITLE
Fix  "missing ';'" error while generating testdata

### DIFF
--- a/testdata/array_basic.zs
+++ b/testdata/array_basic.zs
@@ -61,4 +61,4 @@ subtype uint32 BlockIndex;
 
 struct PackedAutoSubtypeUInt32Array {
     packed BlockIndex blockIndexArray[];
-}
+};


### PR DESCRIPTION
- Semicolon was missing in the zs definition files.