### PR TITLE
Adds Additional Log Information during Code Generation

### DIFF
--- a/internal/cli/generate.go
+++ b/internal/cli/generate.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"fmt"
+	"log"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -21,17 +22,15 @@ var generateCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		m, err := model.FromFilesystem(args[0])
 		if err != nil {
-			fmt.Fprintf(cmd.ErrOrStderr(), "Parse error: %v", err)
-			return err
+			return fmt.Errorf("parse schema: %w", err)
 		}
-		fmt.Printf("Parsing complete, generating files...\n")
+		log.Println("Parsing complete, generating files...")
 		if err = generator.Generate(m, strings.TrimSpace(outputDirectory), &generator.Options{
 			RootPackage: strings.TrimSpace(topLevelPackage),
 		}); err != nil {
-			fmt.Fprintf(cmd.ErrOrStderr(), "Code generation error: %v", err)
-			return err
+			return fmt.Errorf("generate code: %w", err)
 		}
-		fmt.Printf("Code generation completed.\n")
+		log.Println("Code generation completed.")
 		return nil
 	},
 }

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -1,7 +1,6 @@
 package cli
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -14,7 +13,6 @@ var rootCmd = &cobra.Command{
 
 func Execute() {
 	if err := rootCmd.Execute(); err != nil {
-		fmt.Println(err)
 		os.Exit(1)
 	}
 }

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -1,7 +1,7 @@
 package model
 
 import (
-	"fmt"
+	"log"
 	"io/fs"
 	"path/filepath"
 	"strings"
@@ -38,7 +38,7 @@ func FromFilesystem(root string) (*Model, error) {
 			return nil
 		}
 
-		fmt.Printf("Parsing file %s...\n", path)
+		log.Printf("Parsing file %s...\n", path)
 		pkg, err := PackageFromFile(path)
 		if err != nil {
 			return err

--- a/internal/visitor/visitor.go
+++ b/internal/visitor/visitor.go
@@ -2,6 +2,7 @@ package visitor
 
 import (
 	"errors"
+	"log"
 	"fmt"
 	"math"
 	"strconv"
@@ -22,12 +23,12 @@ type Visitor struct {
 func (v *Visitor) Visit(tree antlr.ParseTree) interface{} {
 	switch t := tree.(type) {
 	case *antlr.ErrorNodeImpl:
-		fmt.Printf("syntax error near '%s'", t.GetText())
+		log.Printf("syntax error near '%s'", t.GetText())
 	default:
 		return tree.Accept(v)
 	}
 
-	return fmt.Errorf("visit result not of a Node")
+	return errors.New("visit result not of a Node")
 }
 
 func (v *Visitor) VisitChildren(node antlr.RuleNode) interface{} {


### PR DESCRIPTION
Tidy up logging in the CLI and wrap errors in the `generate` sub-command. This ensures that we are not duplicated error logs and that we know more about what the CLI is doing.

# Example output

## Happy path

```bash
$ bazel run //cmd/zserio -- generate -r myproject.com -o ~/tmp/bar/baz ${PWD}/testdata/reference_modules/
# <bazel output snipped>
2022/02/04 11:15:53 Parsing file <path-to-repo>/testdata/reference_modules/all.zs...
2022/02/04 11:15:53 Parsing file <path-to-repo>/testdata/reference_modules/core/instantiations.zs...
2022/02/04 11:15:53 Parsing file <path-to-repo>/testdata/reference_modules/core/templates.zs...
2022/02/04 11:15:53 Parsing file <path-to-repo>/testdata/reference_modules/core/types.zs...
2022/02/04 11:15:53 Parsing file <path-to-repo>/testdata/reference_modules/testobject1/testobject.zs...
2022/02/04 11:15:53 Parsing complete, generating files...
2022/02/04 11:15:53 Writing ~/tmp/bar/baz/reference_modules/core/templates/pkg.go
2022/02/04 11:15:53 Writing ~/tmp/bar/baz/reference_modules/core/types/pkg.go
2022/02/04 11:15:53 Writing ~/tmp/bar/baz/reference_modules/core/types/color.go
2022/02/04 11:15:53 Writing ~/tmp/bar/baz/reference_modules/core/types/city_attributes.go
2022/02/04 11:15:53 Writing ~/tmp/bar/baz/reference_modules/core/types/value_wrapper.go
2022/02/04 11:15:53 Writing ~/tmp/bar/baz/reference_modules/testobject1/testobject/pkg.go
2022/02/04 11:15:53 Writing ~/tmp/bar/baz/reference_modules/testobject1/testobject/test_object.go
2022/02/04 11:15:53 Writing ~/tmp/bar/baz/reference_modules/all/pkg.go
2022/02/04 11:15:53 Writing ~/tmp/bar/baz/reference_modules/core/instantiations/pkg.go
2022/02/04 11:15:53 Writing ~/tmp/bar/baz/reference_modules/core/instantiations/instantiated_template_struct.go
2022/02/04 11:15:53 Code generation completed.
```
## Error on writing generated files

```bash
$ bazel run //cmd/zserio -- generate -r myproject.com -o / ${PWD}/testdata/reference_modules
# <bazel output snipped>
2022/02/04 11:18:43 Parsing file <path-to-repo>/testdata/reference_modules/all.zs...
2022/02/04 11:18:43 Parsing file <path-to-repo>/testdata/reference_modules/core/instantiations.zs...
2022/02/04 11:18:43 Parsing file <path-to-repo>/testdata/reference_modules/core/templates.zs...
2022/02/04 11:18:43 Parsing file <path-to-repo>/testdata/reference_modules/core/types.zs...
2022/02/04 11:18:43 Parsing file <path-to-repo>/testdata/reference_modules/testobject1/testobject.zs...
2022/02/04 11:18:43 Parsing complete, generating files...
2022/02/04 11:18:43 Writing /reference_modules/core/instantiations/pkg.go
Error: generate code: mkdir /reference_modules: read-only file system
Usage:
  go-zserio generate [flags]

Flags:
  -h, --help                 help for generate
  -o, --out string           Output directory to generate Go files to
  -r, --rootpackage string   Name of the root package package
```

## Error during parsing

```bash
$ bazel run //cmd/zserio -- generate -r myproject.com -o / /tmp/baz
# <bazel output snipped>
Error: parse schema: lstat /tmp/baz: no such file or directory
Usage:
  go-zserio generate [flags]

Flags:
  -h, --help                 help for generate
  -o, --out string           Output directory to generate Go files to
  -r, --rootpackage string   Name of the root package package
```