### PR TITLE
Silence log output during go binding generation

### DIFF
--- a/test/go/BUILD.bazel
+++ b/test/go/BUILD.bazel
@@ -22,7 +22,7 @@ genrule(
         "reference_modules/core/types/city_attributes.go",
         "reference_modules/core/types/value_wrapper.go",
     ],
-    cmd = "$(execpath //zserio) generate --rootpackage {rootpackage} --out {out} {proto_dir}".format(
+    cmd = "$(execpath //zserio) generate --rootpackage {rootpackage} --out {out} {proto_dir} &>1".format(
         rootpackage=rootpkg,
         out="$(@D)",
         proto_dir="testdata/reference_modules",


### PR DESCRIPTION
A followup to #25. Noticed that the `log` package is by default writing to `stderr`, so this should pipe all of the generator output to `stdout`, which is stored by bazel and then does not show up during `bazel test //...`
