### PR TITLE
Refactor generator.writeSource for better debbuging experience

### DIFF
--- a/internal/generator/gen.go
+++ b/internal/generator/gen.go
@@ -83,7 +83,7 @@ func formatGoSource(code []byte) ([]byte, error) {
 
 	formatted, err := format.Source(code)
 	if err != nil {
-		log.Println(code)
+		log.Println(string(code))
 		return nil, fmt.Errorf("format: %w", err)
 	}
 


### PR DESCRIPTION
Currently the errors from the `format.Source` are hard to understand because the function overrides the parameters passed to the function. Change this by splitting everything into smaller functions.
