### PR TITLE
add the first reference data (de)serialization benchmarks

### DIFF
--- a/test/reference/reference_test.go
+++ b/test/reference/reference_test.go
@@ -102,3 +102,43 @@ func want() testobject.TestObject {
 	d.Foo = 42
 	return d
 }
+
+func BenchmarkUnmarshalZserio(b *testing.B) {
+	bin, err := os.ReadFile(ReferenceFilePath)
+	if err != nil {
+		b.Errorf("read reference binary: %w", err)
+		return
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		var testObject testobject.TestObject
+		if err := zserio.Unmarshal(bin, &testObject); err != nil {
+			b.Errorf("unmarshal reference: %w", err)
+			return
+		}
+		_ = testObject
+	}
+	b.StopTimer()
+}
+
+func BenchmarkMarshalZserio(b *testing.B) {
+	testObject := want()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		got, err := zserio.Marshal(&testObject)
+		if err != nil {
+			b.Errorf("marshal: %w", err)
+			return
+		}
+
+		if len(got) == 0 {
+			b.Errorf("got empty buffer")
+			return
+		}
+	}
+	b.StopTimer()
+}


### PR DESCRIPTION
Whilst working on the #64, I would like to know if there is any performance penalty in using interfaces in our `ztype` methods. For that I would like to add this high level benchmark, which can act as a smoke-test type benchmark.

You can run it with:
```bash
$ bazel run //test/reference:reference_test -- -test.bench=.
INFO: Analyzed target //test/reference:reference_test (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //test/reference:reference_test up-to-date:
  bazel-bin/test/reference/reference_test_/reference_test
INFO: Elapsed time: 0.205s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
INFO: Running command line: external/bazel_tools/tools/test/test-setup.sh test/reference/reference_test_/r
INFO: Build completed successfully, 1 total action
exec ${PAGER:-/usr/bin/less} "$0" || exit 1
Executing tests from //test/reference:reference_test
-----------------------------------------------------------------------------
goos: darwin
goarch: amd64
cpu: Intel(R) Core(TM) i5-1038NG7 CPU @ 2.00GHz
BenchmarkUnmarshalZserio-8         97063             11791 ns/op            8528 B/op        272 allocs/op
BenchmarkMarshalZserio-8          116094             11261 ns/op            6648 B/op        153 allocs/op
PASS
```
