### PR TITLE
Fix Generation of Optional Types

### DIFF
--- a/internal/generator/templates/encode_compound_parameters.go.tmpl
+++ b/internal/generator/templates/encode_compound_parameters.go.tmpl
@@ -8,9 +8,6 @@
         for _, element := range {{ $field_name }} {
         {{- $field_name = "element" }}
     {{- end }}
-    {{- if $field.IsOptional }}
-        {{- $field_name = "element" }}
-    {{- end }}
     {{- $type_parameter := getTypeParameter $scope $field.Type }}
     {{- range $i, $argument := $field.Type.TypeArguments }}
         {{- $current_type_parameter := index $type_parameter $i }}


### PR DESCRIPTION
- This is a bugfix to fix the generation of optional types. The
  deleted lines were previously unintendendly commited.
- Issue was introduced with https://github.com/woven-planet/go-zserio/pull/41. 