### PR TITLE
Enhance the Test Case with Optional Choices

### DIFF
--- a/test/python/BUILD.bazel
+++ b/test/python/BUILD.bazel
@@ -28,6 +28,7 @@ genrule(
         "testdata/reference_modules/core/__init__.py",
         "testdata/reference_modules/core/instantiations/__init__.py",
         "testdata/reference_modules/core/instantiations/api.py",
+        "testdata/reference_modules/core/instantiations/instantiated_template_choice.py",
         "testdata/reference_modules/core/instantiations/instantiated_template_struct.py",
         "testdata/reference_modules/core/api.py",
         "testdata/reference_modules/core/templates/__init__.py",

--- a/test/python/write_test_data.py
+++ b/test/python/write_test_data.py
@@ -6,6 +6,9 @@ import zserio
 from testdata.reference_modules.core.instantiations.instantiated_template_struct import (
     InstantiatedTemplateStruct,
 )
+from testdata.reference_modules.core.instantiations.instantiated_template_choice import (
+    InstantiatedTemplateChoice,
+)
 from testdata.reference_modules.testobject1.testobject.test_object import TestObject
 from testdata.reference_modules.core.types.value_wrapper import ValueWrapper
 from testdata.reference_modules.core.types.color import Color
@@ -43,6 +46,11 @@ def _new_test_object():
     for i in range(100):
         d.bitmask_array.append(CityAttributes.from_value(2))
 
+    # d.option_choice1 is deliberately not set
+    d.parameter3 = 12
+    d.option_choice2 = InstantiatedTemplateChoice(d.parameter3)
+    d.option_choice2.default_field = 707
+    d.foo = 42
     return d
 
 def main():

--- a/testdata/reference_modules/core/instantiations.zs
+++ b/testdata/reference_modules/core/instantiations.zs
@@ -5,3 +5,6 @@ import reference_modules.core.types.*;
 
 /** Test instantiation with int32 and dummy struct */
 instantiate TestTemplatedStructWithTypeParamters<int32, ValueWrapper> InstantiatedTemplateStruct;
+
+/** Test instantiation of choice */
+instantiate TemplatedChoice<int32, ValueWrapper> InstantiatedTemplateChoice;

--- a/testdata/reference_modules/testobject1/testobject.zs
+++ b/testdata/reference_modules/testobject1/testobject.zs
@@ -16,4 +16,17 @@ struct TestObject
     packed InstantiatedTemplateStruct(parameter2) structArray[];
     align(5):
     CityAttributes bitmaskArray[100];
+
+    // Parameter for optional choices
+    int32 parameter3;
+
+    // The first optional choice, expected to not be present in the data
+    optional InstantiatedTemplateChoice(parameter3) optionChoice1;
+
+    // the second optional choice, expected to be present in the data
+    optional InstantiatedTemplateChoice(parameter3) optionChoice2;
+
+    // foo is just there to have something after an optional type
+    varint32 foo;
+    
 };


### PR DESCRIPTION
- The test case which compares go-zserio against the reference implementation
  is improved by addition optional fields. This should cover issues we
  previously faced when generating optional fields.
- To make this a bit more complex, these optional fields are choice types,
  that are generated from templated types, and are using parameters.
- This should prevent issues such as https://github.com/woven-planet/go-zserio/pull/46 from occurring again.

This PR adds some tests that revealed several issues related to the way choices are implemented. Therefore, this PR should only be merged once https://github.com/woven-planet/go-zserio/pull/48 is merged.