### PR TITLE
Support Instantiating Choice Templates

### DIFF
--- a/internal/generator/templates/choice.go.tmpl
+++ b/internal/generator/templates/choice.go.tmpl
@@ -93,11 +93,9 @@ func (v *{{ $choice.Name}}) ZserioBitSize(bitPosition int) (int, error) {
     {{- template "bitsizeof.go.tmpl" dict "pkg" $scope "field" .Field "isarray" false}}
   {{- end }}
 {{- end }}
-{{- if $choice.DefaultCase }}
-  {{- if $choice.DefaultCase.Field }}
+{{- if and $choice.DefaultCase $choice.DefaultCase.Field }}
   default:
    {{- template "bitsizeof.go.tmpl" dict "pkg" $scope "field" $choice.DefaultCase.Field "isarray" false}}
-  {{- end }}
 {{- end }}
   }
   return endBitPosition - bitPosition, nil
@@ -109,10 +107,8 @@ func (v *{{ $choice.Name}}) ZserioCreatePackingContext(contextNode *zserio.Packi
     {{- template "packing_context_create.go.tmpl" dict "pkg" $scope "field" .Field }}
   {{- end }}
 {{- end }}
-{{- if $choice.DefaultCase }}
-  {{- if $choice.DefaultCase.Field }}
+{{- if and $choice.DefaultCase $choice.DefaultCase.Field }}
    {{- template "packing_context_create.go.tmpl" dict "pkg" $scope "field" $choice.DefaultCase.Field }}
-  {{- end }}
 {{- end }}
   return nil
 }
@@ -130,11 +126,9 @@ func (v *{{ $choice.Name}}) ZserioInitPackingContext(contextNode *zserio.Packing
       {{- $index = (add $index 1) }}
     {{- end }}
   {{- end }}
-  {{- if $choice.DefaultCase }}
-    {{- if $choice.DefaultCase.Field }}
+  {{- if and $choice.DefaultCase $choice.DefaultCase.Field }}
     default:
     {{- template "packing_context_create.go.tmpl" dict "pkg" $scope "field" $choice.DefaultCase.Field }}
-    {{- end }}
   {{- end }}
   }
 {{- end }}
@@ -155,11 +149,9 @@ func (v *{{ $choice.Name}}) UnmarshalZserioPacked(contextNode *zserio.PackingCon
       {{- $index = (add $index 1) }}
     {{- end }}
   {{- end}}
-  {{- if $choice.DefaultCase }}
-    {{- if $choice.DefaultCase.Field }}
+  {{- if and $choice.DefaultCase $choice.DefaultCase.Field }}
     default:
     {{ template "packing_context_decode.go.tmpl" dict "pkg" $scope "field" $choice.DefaultCase.Field "index" $index }}
-    {{- end }}
   {{- end }}
   }
     _ = err // to avoid "declared but not used" warning
@@ -181,11 +173,9 @@ func (v *{{ $choice.Name}}) MarshalZserioPacked(contextNode *zserio.PackingConte
       {{- $index = (add $index 1) }}
     {{- end }}
   {{- end}}
-  {{- if $choice.DefaultCase }}
-    {{- if $choice.DefaultCase.Field }}
+  {{- if and $choice.DefaultCase $choice.DefaultCase.Field }}
     default:
     {{template "packing_context_encode.go.tmpl" dict "pkg" $scope "field" $choice.DefaultCase.Field "index" $index }}
-    {{- end }}
   {{- end }}
   }
     _ = err // to avoid "declared but not used" warning
@@ -211,11 +201,9 @@ func (v *{{ $choice.Name}}) ZserioBitSizePacked(contextNode *zserio.PackingConte
       {{- $index = (add $index 1) }}
     {{- end }}
   {{- end}}
-  {{- if $choice.DefaultCase }}
-    {{- if $choice.DefaultCase.Field }}
+  {{- if and $choice.DefaultCase $choice.DefaultCase.Field }}
     default:
     {{- template "packing_context_bitsize.go.tmpl" dict "pkg" $scope "field" $choice.DefaultCase.Field "index" $index }}
-    {{- end }}
   {{- end }}
   }
 {{- end }}

--- a/internal/generator/templates/choice.go.tmpl
+++ b/internal/generator/templates/choice.go.tmpl
@@ -11,6 +11,11 @@ type {{ $choice.Name }} struct {
     {{- template "field_declaration.go.tmpl" dict "pkg" $scope "field" .Field }}
   {{- end }}
 {{- end }}
+{{- if $choice.DefaultCase }}
+  {{- if $choice.DefaultCase.Field }}
+    {{- template "field_declaration.go.tmpl" dict "pkg" $scope "field" $choice.DefaultCase.Field }}
+  {{- end }}
+{{- end }}
 }
 
 func (v *{{ $choice.Name}}) Clone() zserio.ZserioType {
@@ -25,50 +30,76 @@ func (v *{{ $choice.Name}}) LoadDefaultValues() error {
     {{template "default_values.go.tmpl" dict "pkg" $scope "field" .Field }}
   {{- end }}
 {{- end}}
+{{- if $choice.DefaultCase }}
+  {{- if $choice.DefaultCase.Field }}
+   {{template "default_values.go.tmpl" dict "pkg" $scope "field" $choice.DefaultCase.Field }}
+  {{- end }}
+{{- end }}
   return nil
 }
 
 // MarshalZserio implements the zserio.Marshaler interface.
 func (v *{{ $choice.Name}}) MarshalZserio(w *bitio.CountWriter) error {
-    var err error
+  var err error
 {{- $expr := $choice.Expression }}
+  switch (v.{{ $expr.ResultSymbol.Symbol.Name }}) {
 {{- range $case := $choice.Cases }}
   {{- if .Field }}
-  if v.{{ $expr.ResultSymbol.Symbol.Name }} == {{ (index .Conditions 0).Condition.ResultIntValue }} { 
+  case {{ (index .Conditions 0).Condition.ResultIntValue }}:
     {{- template "encode.go.tmpl" dict "pkg" $scope "field" .Field }}
-  }
   {{- end }}
 {{- end }}
-    _ = err // to avoid "declared but not used" warning
-    return nil
+{{- if $choice.DefaultCase }}
+  {{- if $choice.DefaultCase.Field }}
+  default:
+   {{- template "encode.go.tmpl" dict "pkg" $scope "field" $choice.DefaultCase.Field }}
+  {{- end }}
+{{- end }}
+  }
+  _ = err // to avoid "declared but not used" warning
+  return nil
 }
 
 // UnmarshalZserio implements the zserio.Unmarshaler interface.
 func (v *{{ $choice.Name}}) UnmarshalZserio(r *bitio.CountReader) error {
     var err error
 {{- $expr := $choice.Expression }}
+  switch (v.{{ $expr.ResultSymbol.Symbol.Name }}) {
 {{- range $case := $choice.Cases }}
   {{- if .Field }}
-  if v.{{ $expr.ResultSymbol.Symbol.Name }} == {{ (index .Conditions 0).Condition.ResultIntValue }} { 
+  case {{ (index .Conditions 0).Condition.ResultIntValue }}: 
     {{- template "decode.go.tmpl" dict "pkg" $scope "field" .Field }}
-  }
   {{- end }}
 {{- end }}
-    _ = err // to avoid "declared but not used" warning
-    return nil
+{{- if $choice.DefaultCase }}
+  {{- if $choice.DefaultCase.Field }}
+  default:
+   {{- template "decode.go.tmpl" dict "pkg" $scope "field" $choice.DefaultCase.Field }}
+  {{- end }}
+{{- end }}
+  }
+  _ = err // to avoid "declared but not used" warning
+  return nil
 }
 
 // ZserioBitSize implements the zserio.Marshaler interface.
 func (v *{{ $choice.Name}}) ZserioBitSize(bitPosition int) (int, error) {
   endBitPosition := bitPosition
 {{- $expr := $choice.Expression }}
+  switch (v.{{ $expr.ResultSymbol.Symbol.Name }}) {
 {{- range $case := $choice.Cases }}
   {{- if .Field }}
-  if v.{{ $expr.ResultSymbol.Symbol.Name }} == {{ (index .Conditions 0).Condition.ResultIntValue }} { 
+  case {{ (index .Conditions 0).Condition.ResultIntValue }}:
     {{- template "bitsizeof.go.tmpl" dict "pkg" $scope "field" .Field "isarray" false}}
-  }
   {{- end }}
 {{- end }}
+{{- if $choice.DefaultCase }}
+  {{- if $choice.DefaultCase.Field }}
+  default:
+   {{- template "bitsizeof.go.tmpl" dict "pkg" $scope "field" $choice.DefaultCase.Field "isarray" false}}
+  {{- end }}
+{{- end }}
+  }
   return endBitPosition - bitPosition, nil
 }
 
@@ -78,6 +109,11 @@ func (v *{{ $choice.Name}}) ZserioCreatePackingContext(contextNode *zserio.Packi
     {{- template "packing_context_create.go.tmpl" dict "pkg" $scope "field" .Field }}
   {{- end }}
 {{- end }}
+{{- if $choice.DefaultCase }}
+  {{- if $choice.DefaultCase.Field }}
+   {{- template "packing_context_create.go.tmpl" dict "pkg" $scope "field" $choice.DefaultCase.Field }}
+  {{- end }}
+{{- end }}
   return nil
 }
 
@@ -85,15 +121,22 @@ func (v *{{ $choice.Name}}) ZserioInitPackingContext(contextNode *zserio.Packing
 {{- if $choice.Cases }}
     childrenNodes := contextNode.GetChildren()
     _ = childrenNodes // to avoid "declared but not used" warning
+    switch (v.{{ $expr.ResultSymbol.Symbol.Name }}) {
   {{- $index := 0 }}
   {{- range $case := $choice.Cases }}
     {{- if .Field }}
-      if v.{{ $expr.ResultSymbol.Symbol.Name }} == {{ (index .Conditions 0).Condition.ResultIntValue }} { 
+      case {{ (index .Conditions 0).Condition.ResultIntValue }}:
       {{- template "packing_context_init.go.tmpl" dict "pkg" $scope "field" .Field "index" $index }}
       {{- $index = (add $index 1) }}
-      }
     {{- end }}
   {{- end }}
+  {{- if $choice.DefaultCase }}
+    {{- if $choice.DefaultCase.Field }}
+    default:
+    {{- template "packing_context_create.go.tmpl" dict "pkg" $scope "field" $choice.DefaultCase.Field }}
+    {{- end }}
+  {{- end }}
+  }
 {{- end }}
   return nil
 }
@@ -103,15 +146,22 @@ func (v *{{ $choice.Name}}) UnmarshalZserioPacked(contextNode *zserio.PackingCon
     var err error
     childrenNodes := contextNode.GetChildren()
     _ = childrenNodes // to avoid "declared but not used" warning
+    switch (v.{{ $expr.ResultSymbol.Symbol.Name }}) {
   {{- $index := 0 }}
   {{- range $case := $choice.Cases }}
     {{- if .Field }}
-      if v.{{ $expr.ResultSymbol.Symbol.Name }} == {{ (index .Conditions 0).Condition.ResultIntValue }} { 
-      {{template "packing_context_decode.go.tmpl" dict "pkg" $scope "field" .Field "index" $index }}
+      case {{ (index .Conditions 0).Condition.ResultIntValue }}:
+      {{ template "packing_context_decode.go.tmpl" dict "pkg" $scope "field" .Field "index" $index }}
       {{- $index = (add $index 1) }}
-      }
     {{- end }}
   {{- end}}
+  {{- if $choice.DefaultCase }}
+    {{- if $choice.DefaultCase.Field }}
+    default:
+    {{ template "packing_context_decode.go.tmpl" dict "pkg" $scope "field" $choice.DefaultCase.Field "index" $index }}
+    {{- end }}
+  {{- end }}
+  }
     _ = err // to avoid "declared but not used" warning
 {{- end }}
     return nil
@@ -122,15 +172,22 @@ func (v *{{ $choice.Name}}) MarshalZserioPacked(contextNode *zserio.PackingConte
     var err error
     childrenNodes := contextNode.GetChildren()
     _ = childrenNodes // to avoid "declared but not used" warning
+    switch (v.{{ $expr.ResultSymbol.Symbol.Name }}) {
   {{- $index := 0 }}
   {{- range $case := $choice.Cases }}
     {{- if .Field }}
-      if v.{{ $expr.ResultSymbol.Symbol.Name }} == {{ (index .Conditions 0).Condition.ResultIntValue }} { 
+      case {{ (index .Conditions 0).Condition.ResultIntValue }}: 
       {{template "packing_context_encode.go.tmpl" dict "pkg" $scope "field" .Field "index" $index }}
       {{- $index = (add $index 1) }}
-      }
     {{- end }}
   {{- end}}
+  {{- if $choice.DefaultCase }}
+    {{- if $choice.DefaultCase.Field }}
+    default:
+    {{template "packing_context_encode.go.tmpl" dict "pkg" $scope "field" $choice.DefaultCase.Field "index" $index }}
+    {{- end }}
+  {{- end }}
+  }
     _ = err // to avoid "declared but not used" warning
 {{- end }}
     return nil
@@ -145,15 +202,22 @@ func (v *{{ $choice.Name}}) ZserioBitSizePacked(contextNode *zserio.PackingConte
 {{- if $choice.Cases }}
   childrenNodes := contextNode.GetChildren()
   _ = childrenNodes // to avoid "declared but not used" warning
-    {{- $index := 0 }}
+  switch (v.{{ $expr.ResultSymbol.Symbol.Name }}) {
+  {{- $index := 0 }}
   {{- range $case := $choice.Cases }}
     {{- if .Field }}
-      if v.{{ $expr.ResultSymbol.Symbol.Name }} == {{ (index .Conditions 0).Condition.ResultIntValue }} { 
+      case {{ (index .Conditions 0).Condition.ResultIntValue }}:
       {{- template "packing_context_bitsize.go.tmpl" dict "pkg" $scope "field" .Field "index" $index }}
       {{- $index = (add $index 1) }}
-      }
     {{- end }}
   {{- end}}
+  {{- if $choice.DefaultCase }}
+    {{- if $choice.DefaultCase.Field }}
+    default:
+    {{- template "packing_context_bitsize.go.tmpl" dict "pkg" $scope "field" $choice.DefaultCase.Field "index" $index }}
+    {{- end }}
+  {{- end }}
+  }
 {{- end }}
   return endBitPosition - bitPosition, nil
 }

--- a/internal/generator/templates/decode.go.tmpl
+++ b/internal/generator/templates/decode.go.tmpl
@@ -59,7 +59,7 @@
         {{- $assign_str_rvalue = printf "%sArrayProperties" $field.Name }}
         {{- template "array_init.go.tmpl" dict "pkg" $scope "field_name" $assign_str_lvalue "field" $field "native" $native }}
     {{- end }}
-    {{- template "decode_compound_parameters.go.tmpl" dict "pkg" $scope "field" $field }}
+    {{- template "decode_compound_parameters.go.tmpl" dict "pkg" $scope "field" $field "field_name" $assign_str_lvalue }}
     if err = {{ $assign_str_rvalue }}.UnmarshalZserio(r); err != nil {
         return err
     }

--- a/internal/generator/templates/decode_compound_parameters.go.tmpl
+++ b/internal/generator/templates/decode_compound_parameters.go.tmpl
@@ -1,16 +1,15 @@
 
 {{ $scope := .pkg }}
 {{ $field := .field }}
-{{ $native := goNativeType $scope $field.Type }}
+{{- $field_name := .field_name }}
 
 {{- if $field.Type.TypeArguments }}
-    {{- $lvalue := printf "v.%s" $field.Name }}
     {{- if $field.Array }}
-        {{- $lvalue = printf "%sArrayProperties.ArrayTraits.DefaultObject" $field.Name }}
+        {{- $field_name = printf "%sArrayProperties.ArrayTraits.DefaultObject" $field.Name }}
     {{- end }}
     {{- $type_parameter := getTypeParameter $scope $field.Type }}
     {{- range $i, $argument := $field.Type.TypeArguments }}
         {{- $current_type_parameter := index $type_parameter $i }}
-        {{ $lvalue }}.{{ $current_type_parameter.Name}} = {{ goType $scope $current_type_parameter.Type }}({{ goExpression $scope $argument }})
+        {{ $field_name }}.{{ $current_type_parameter.Name}} = {{ goType $scope $current_type_parameter.Type }}({{ goExpression $scope $argument }})
     {{- end}}
 {{- end }}

--- a/internal/generator/templates/packing_context_decode.go.tmpl
+++ b/internal/generator/templates/packing_context_decode.go.tmpl
@@ -39,7 +39,7 @@
     {{- template "array_init.go.tmpl" dict "pkg" $scope "field_name" $assign_str_lvalue "field" $field "native" $native }}
     {{- end }}
     
-    {{- template "decode_compound_parameters.go.tmpl" dict "pkg" $scope "field" $field }}
+    {{- template "decode_compound_parameters.go.tmpl" dict "pkg" $scope "field" $field "field_name" $assign_str_lvalue }}
 
     {{- if $field.Array }}
         {{- if not $field.Array.IsPacked }}

--- a/internal/generator/templates/packing_context_init.go.tmpl
+++ b/internal/generator/templates/packing_context_init.go.tmpl
@@ -22,7 +22,7 @@
     {{- if $field.OptionalClause }}
         if {{ goExpression $scope $field.OptionalClause }} {
     {{- end }}
-    {{- template "decode_compound_parameters.go.tmpl" dict "pkg" $scope "field" $field }}
+    {{- template "decode_compound_parameters.go.tmpl" dict "pkg" $scope "field" $field "field_name" $field_name }}
     {{- if $native.IsMarshaler }}
         if err := {{ $field_name }}.ZserioInitPackingContext(childrenNodes[{{ $index }}]); err != nil {
             return err

--- a/internal/model/BUILD.bazel
+++ b/internal/model/BUILD.bazel
@@ -19,7 +19,10 @@ go_library(
 
 go_test(
     name = "model_test",
-    srcs = ["model_test.go"],
+    srcs = [
+        "model_test.go",
+        "transform_test.go",
+    ],
     data = ["//testdata:examples"],
     embed = [":model"],
     env = {
@@ -27,6 +30,7 @@ go_test(
     },
     deps = [
         "//internal/ast",
+        "@com_github_google_go_cmp//cmp",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
     ],

--- a/internal/model/transform.go
+++ b/internal/model/transform.go
@@ -103,6 +103,12 @@ func (m *Model) CapitalizeNames() {
 					}
 				}
 			}
+			if choice.DefaultCase != nil && choice.DefaultCase.Field != nil {
+				choice.DefaultCase.Field.Name = strings.Title(choice.DefaultCase.Field.Name)
+				if !choice.DefaultCase.Field.Type.IsBuiltin {
+					choice.DefaultCase.Field.Type.Name = strings.Title(choice.DefaultCase.Field.Type.Name)
+				}
+			}
 			for _, function := range choice.Functions {
 				function.Name = strings.Title(function.Name)
 			}

--- a/internal/model/transform_test.go
+++ b/internal/model/transform_test.go
@@ -1,0 +1,108 @@
+package model_test
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/woven-planet/go-zserio/internal/ast"
+	"github.com/woven-planet/go-zserio/internal/model"
+)
+
+func TestTemplateInstantiationStruct(t *testing.T) {
+	tests := map[string]struct {
+		testPackage           *ast.Package
+		testTypeInstantiation *ast.InstantiateType
+		resultingType         *ast.Struct
+	}{
+		"test-struct-template-instantiation-with-native-types": {
+			testPackage: &ast.Package{
+				Name: "test_package",
+				Structs: map[string]*ast.Struct{
+					"template_struct": {
+						Name:               "template_struct",
+						TemplateParameters: []string{"T", "V"},
+						Fields: []*ast.Field{
+							{
+								Name: "field_a",
+								Type: &ast.TypeReference{
+									Name: "T",
+								},
+							},
+							{
+								Name: "field_b",
+								Type: &ast.TypeReference{
+									Name: "V",
+								},
+							},
+						},
+					},
+				},
+			},
+			testTypeInstantiation: &ast.InstantiateType{
+				Name: "struct_instantiation",
+				Type: &ast.TypeReference{
+					Name:    "template_struct",
+					Package: "test_package",
+					TemplateArguments: []*ast.TypeReference{
+						{
+							Name:      "int64",
+							IsBuiltin: true,
+						},
+						{
+							Name:      "int32",
+							IsBuiltin: true,
+						},
+					},
+				},
+			},
+			resultingType: &ast.Struct{
+				Name: "struct_instantiation",
+				Fields: []*ast.Field{
+					{
+						Name: "field_a",
+						Type: &ast.TypeReference{
+							Name:      "int64",
+							IsBuiltin: true,
+						},
+					},
+					{
+						Name: "field_b",
+						Type: &ast.TypeReference{
+							Name:      "int32",
+							IsBuiltin: true,
+						},
+					},
+				},
+			},
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			// use the test data to build up a model
+			test.testPackage.InstantiatedTypes = map[string]*ast.InstantiateType{
+				test.testTypeInstantiation.Name: test.testTypeInstantiation,
+			}
+			m := &model.Model{
+				Packages: map[string]*ast.Package{
+					test.testPackage.Name: test.testPackage,
+				},
+			}
+			if err := test.testPackage.CollectSymbols(); err != nil {
+				t.Fatalf("error during symbol collection: %v", err)
+			}
+
+			if err := m.InstantiateTemplates(); err != nil {
+				t.Fatalf("error during template instantiation: %v", err)
+			}
+
+			// search for the instantiated struct
+			if s, ok := test.testPackage.Structs[test.resultingType.Name]; !ok {
+				t.Fatalf("instantiated struct not found : %s", test.resultingType.Name)
+			} else {
+				if diff := cmp.Diff(test.resultingType, s); diff != "" {
+					t.Errorf("template instantiation does not match: %s", diff)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Choices were so far greatly neglected, mainly because there are not frequently used.

This PR fixes the following:
- So far, template instantiation of compound types only  worked for structs. This PR adds support for instantiating templated choices.
- The default case of choices was completely ignored so far. This PR adds a) capitalization of the default case, b) the default case is added in the Marshal/Unmarshal/BitSize functions, c) the field member for the default choice now gets generated.
- The branching for choices was changed from a series of `if()` to a `switch:case`. The generated code not only looks cleaner, but should also run a tad faster. 
- A bug causing a segfault when passing parameters to optional fields is also fixed. This bug does not only affect choices, but all compound types (structs, enums, choices).