### PR TITLE
Move tests requiring generated files behind tag

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,7 +22,7 @@ jobs:
 
       - name: gazelle
         run: |
-          ./bin/ensure-unchanged ./bin/gazelle
+          ./bin/ensure-unchanged ./bin/gazelle -- -build_tags integration
           ./bin/ensure-unchanged ./bin/gazelle-update-repos
 
       - run: bazel test //...

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -66,6 +66,7 @@ load("//:deps.bzl", "go_dependencies")
 protobuf_deps()
 
 # gazelle:repository_macro deps.bzl%go_dependencies
+# gazelle:build_tags integration
 go_dependencies()
 
 rules_antlr_dependencies("4.8", GO)

--- a/bin/gazelle-update-repos
+++ b/bin/gazelle-update-repos
@@ -2,4 +2,4 @@
 set -euo pipefail
 
 bazel run @go_sdk//:bin/go -- mod tidy -v
-exec bazel run //:gazelle -- update-repos -from_file=go.mod -to_macro=deps.bzl%go_dependencies
+exec bazel run //:gazelle -- update-repos -from_file=go.mod -to_macro=deps.bzl%go_dependencies -build_tags integration

--- a/internal/generator/BUILD.bazel
+++ b/internal/generator/BUILD.bazel
@@ -58,6 +58,7 @@ go_test(
     env = {
         "TEST_ZSERIO_EXAMPLES": "$(rootpaths //testdata:examples)",
     },
+    gotags = ["integration"],
     deps = [
         "//internal/ast",
         "//internal/model",

--- a/internal/generator/gen_test.go
+++ b/internal/generator/gen_test.go
@@ -1,3 +1,6 @@
+//go:build integration
+// +build integration
+
 package generator
 
 import (

--- a/internal/model/BUILD.bazel
+++ b/internal/model/BUILD.bazel
@@ -28,6 +28,7 @@ go_test(
     env = {
         "TEST_ZSERIO_EXAMPLES": "$(rootpaths //testdata:examples)",
     },
+    gotags = ["integration"],
     deps = [
         "//internal/ast",
         "@com_github_google_go_cmp//cmp",

--- a/internal/model/model_test.go
+++ b/internal/model/model_test.go
@@ -1,3 +1,6 @@
+//go:build integration
+// +build integration
+
 package model
 
 import (

--- a/test/BUILD.bazel
+++ b/test/BUILD.bazel
@@ -25,6 +25,7 @@ go_test(
     env = {
         "TESTDATA_BIN": "$(rootpath :testdata)",
     },
+    gotags = ["integration"],
     deps = [
         "//test/go:testobject",
         "@com_github_cucumber_godog//:godog",

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -1,3 +1,6 @@
+//go:build integration
+// +build integration
+
 package go_test
 
 import (


### PR DESCRIPTION
Running `go test ./...` on a checkout is failing due to missing files:

```
test/integration_test.go:17:2: package gen/github.com/woven-planet/go-zserio/test/go/reference_modules/testobject1/testobject is not in GOROOT (/Users/wichert/sdk/go1.18beta2/src/gen/github.com/woven-planet/go-zserio/test/go/reference_modules/testobject1/testobject)
FAIL	github.com/woven-planet/go-zserio/test [setup failed]
?   	github.com/woven-planet/go-zserio	[no test files]
?   	github.com/woven-planet/go-zserio/cmd/zserio	[no test files]
?   	github.com/woven-planet/go-zserio/interface	[no test files]
?   	github.com/woven-planet/go-zserio/internal	[no test files]
?   	github.com/woven-planet/go-zserio/internal/ast	[no test files]
?   	github.com/woven-planet/go-zserio/internal/cli	[no test files]
# github.com/woven-planet/go-zserio/internal/model
internal/model/model_test.go:51:5: (*testing.common).Errorf format %q has arg item of wrong type *github.com/woven-planet/go-zserio/internal/ast.EnumItem
--- FAIL: TestStableOutputOrder (0.00s)
    --- FAIL: TestStableOutputOrder/. (0.00s)
        gen_test.go:36: 
            	Error Trace:	gen_test.go:36
            	Error:      	Received unexpected error:
            	            	open : no such file or directory
            	Test:       	TestStableOutputOrder/.
    --- FAIL: TestStableOutputOrder/.#01 (0.00s)
        gen_test.go:36: 
            	Error Trace:	gen_test.go:36
            	Error:      	Received unexpected error:
            	            	open : no such file or directory
            	Test:       	TestStableOutputOrder/.#01
FAIL
FAIL	github.com/woven-planet/go-zserio/internal/generator	0.307s
FAIL	github.com/woven-planet/go-zserio/internal/model [build failed]
?   	github.com/woven-planet/go-zserio/internal/parser	[no test files]
?   	github.com/woven-planet/go-zserio/internal/visitor	[no test files]
ok  	github.com/woven-planet/go-zserio/ztype	(cached)
FAIL
```

to allow people to run tests without babel this PR introduces an `integration` build tag for those tags, so those tests are skipped by default. The bazel configuration is updated to use the `integration` tag in `go_test`.