### PR TITLE
Support running tests without bazel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 *.sw[op]
 .DS_Store
 .envrc.local
+/testdata/testdata.bin
+/test/go/reference_modules
+/test/python/testdata

--- a/bin/prepare-testdata
+++ b/bin/prepare-testdata
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+GO=${GO:-go1.18beta2}
+set -e
+
+# Prepare reference test data using zserio Pytho implementation
+python3 -m venv .venv
+source .venv/bin/activate
+pip install zserio
+
+zserio -src testdata reference_modules/all.zs -setTopLevelPackage testdata -python test/python
+python test/python/write_test_data.py
+
+# Generate Go code for schema
+$GO run ./cmd/zserio generate \
+    -r gen/github.com/woven-planet/go-zserio/test/go/reference_modules \
+    -o test/go \
+    testdata/reference_modules


### PR DESCRIPTION
Running the tests require a bit of preparation: generate test data using the Python zserio implementation, and generating Go code for the test zserio schema. Bazel normally handles all of that automatically, but to support people who do not want to use bazel there is now a prepare-testdata script that will do the same thing.

This PR is not complete: the tests expect to be able to import `gen/github.com/woven-planet/go-zserio/test/go/reference_modules`, but that is not setup in GOROOT. I'm not sure what the best way to address that is

@aignas perhaps we can move `reference_modules` under the normal `github.com/woven-planet/go-zserio` package without breaking our bazel setup?