### PR TITLE
Add automated release configuration

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,22 @@
+changelog:
+  exclude:
+    labels:
+      - ignore for release
+      - duplicate
+    authors:
+      - dependabot
+  categories:
+    - title: Breaking Changes 🛠
+      labels:
+        - Semver-Major
+        - breaking change
+    - title: New Features 🎉
+      labels:
+        - Semver-Minor
+        - enhancement
+    - title: Bug Fixes
+      labels:
+        - bug
+    - title: Other Changes
+      labels:
+        - "*"


### PR DESCRIPTION
Add a configuration file to help [GitHub create automated release notes](https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes).
