### PR TITLE
Added a function to export the bit count of the writer object

### DIFF
--- a/zstream/writer.go
+++ b/zstream/writer.go
@@ -85,3 +85,8 @@ func (w *BitWriter) Align(boundary uint8) (int64, error) {
 func (w *BitWriter) Close() error {
 	return w.writer.Close()
 }
+
+// BitPosition returns the number of bits written
+func (w *BitWriter) BitPosition() int64 {
+	return w.writer.BitsCount
+}


### PR DESCRIPTION
- In some cases, the application needs to know the exact bit size of
  the generated file (not the number of bytes).
- Therefore, this newly added function allows exporting the exact
  bit size of the writer.