### PR TITLE
Fix the NumBits() Operator

### DIFF
--- a/internal/generator/expression.go
+++ b/internal/generator/expression.go
@@ -57,11 +57,7 @@ func dotOperatorToGoString(scope ast.Scope, expression *ast.Expression) string {
 }
 
 func numBitsOperatorToGoString(scope ast.Scope, expression *ast.Expression) string {
-	// TODO this is a very weak way of getting the bitsize, but fixing this
-	// properly needs a major refactoring in expression handling (need to find
-	// out the type (signed/unsigned) of the expression result, and perhaps
-	// even the maximum/minimum bit size.
-	return fmt.Sprintf("ztype.TryUnsignedBitSize(uint64(%s))", ExpressionToGoString(scope, expression.Operand1))
+	return fmt.Sprintf("ztype.NumBits(uint64(%s))", ExpressionToGoString(scope, expression.Operand1))
 }
 
 func getSymbolType(scope ast.Scope, symbol *ast.SymbolReference) (*ast.TypeReference, error) {

--- a/ztype/varuint_encode.go
+++ b/ztype/varuint_encode.go
@@ -2,6 +2,7 @@ package ztype
 
 import (
 	"errors"
+	"math/bits"
 
 	zserio "github.com/woven-planet/go-zserio"
 )
@@ -77,14 +78,6 @@ func writeVarUint(w zserio.Writer, v uint64, maxBytes int) error {
 	return err
 }
 
-// TryUnsignedBitSize is a simplified version of UnsignedBitSize(), that is
-// needed for use within expressions. Within an expression, there is no possibility
-// for error checking or branching.
-func TryUnsignedBitSize(v uint64) int {
-	value, _ := UnsignedBitSize(v, 64)
-	return value
-}
-
 // UnsignedBitSize returns the size in bits of the zserio encoding of an unsigned
 // value.
 func UnsignedBitSize(v uint64, maxBytes int) (int, error) {
@@ -115,4 +108,9 @@ func UnsignedBitSize(v uint64, maxBytes int) (int, error) {
 			max = (max << 7) | 0xff
 		}
 	}
+}
+
+// NumBits returns the exact number of bits of an unsigned integer.
+func NumBits(v uint64) int {
+	return bits.Len64(v)
 }

--- a/ztype/varuint_encode_test.go
+++ b/ztype/varuint_encode_test.go
@@ -400,3 +400,23 @@ func BenchmarkBitsize(b *testing.B) {
 		_, _ = ztype.UnsignedBitSize((1<<28)-1, 8)
 	}
 }
+
+func TestNumBits(t *testing.T) {
+
+	tests := map[string]struct {
+		expected int
+		value    uint64
+	}{
+		"empty":  {0, 0},
+		"one":    {1, 1},
+		"random": {9, 264},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := ztype.NumBits(test.value)
+			if got != test.expected {
+				t.Errorf("incorrect number of bits for %d: got %d, want %d", test.value, got, test.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
- The NumBits() operator previously called TryUnsignedBitSize(), which
  did not return the actual number of bits, but rather the zserio type
  bit size. This yielded incorrect results.
- The NumBits() operator now calls bits.Len64(), which correctly
  calculates the number of bits for an uint.