### PR TITLE
Fix Encoding/Decoding of optional struct fields in packed arrays

### DIFF
--- a/internal/generator/templates/packing_context_create.go.tmpl
+++ b/internal/generator/templates/packing_context_create.go.tmpl
@@ -2,23 +2,10 @@
 {{ $field := .field }}
 {{ $index := .index }}
 {{ $native := goNativeType $scope $field.Type }}
-{{- $field_name := printf "v.%s" $field.Name }}
-{{- if $field.IsOptional}}
-    {{- $field_name = printf "(*v.%s)" $field.Name }}
-{{- end }}
-{{- if and $native.RequiresCast (not $field.Array) }}
-    {{- if $native.IsMarshaler }}
-        {{- $field_name = printf "(*%s)(&v.%s)" (goType $scope $native.Type) $field.Name }}
-        {{- if $field.IsOptional}}
-            {{- $field_name = printf "(*%s)(v.%s)" (goType $scope $native.Type) $field.Name }}
-        {{- end }}
-    {{- else }}
-        {{- $field_name = printf "%s(%s)" (goType $scope $native.Type) $field_name }}
-    {{- end }}
-{{- end }}
+
 field{{ $field.Name }}Node := &zserio.PackingContextNode{}
 contextNode.AddChild(field{{ $field.Name }}Node)
-{{- if and (not $field.Array) (not $field.IsOptional) (not (eq $native.Type.Name "bool")) (not (eq $native.Type.Name "string")) (not (eq $native.Type.Name "extern")) }}
+{{- if and (not $field.Array) (not (eq $native.Type.Name "bool")) (not (eq $native.Type.Name "string")) (not (eq $native.Type.Name "extern")) }}
     {{- if $native.IsMarshaler }}
         var field{{ $field.Name }}Ptr *{{ goType $scope $native.Type }}
         if err := field{{ $field.Name }}Ptr.ZserioCreatePackingContext(field{{ $field.Name }}Node); err != nil {

--- a/internal/generator/templates/packing_context_decode.go.tmpl
+++ b/internal/generator/templates/packing_context_decode.go.tmpl
@@ -21,92 +21,107 @@
     {{- end }}
 {{- end }}
 
+{{- if $field.OptionalClause }}
+    if {{ goExpression $scope $field.OptionalClause }} {
+{{- end }}
+
+{{- $assign_str_lvalue := printf "v.%s" $field.Name }}
+{{- $assign_str_rvalue := $field_name }}
+
 {{- if $field.IsOptional}}
-    // this field is optional, and therefore uses the standard packing approach
-    {{- template "decode.go.tmpl" dict "pkg" $scope "field" $field }}
-{{- else }}
-    {{- if $field.OptionalClause }}
-        if {{ goExpression $scope $field.OptionalClause }} {
-    {{- end }}
-    {{- if not (eq $field.Alignment 0) }}
-        r.Align({{ $field.Alignment }})
-    {{- end }}
-
-    {{- $assign_str_lvalue := printf "v.%s" $field.Name }}
-    {{- $assign_str_rvalue := $field_name }}
+    if present, err := ztype.ReadBool(r); err != nil {
+        return err
+    } else if present {
 
     {{- if $field.Array }}
-    {{- template "array_init.go.tmpl" dict "pkg" $scope "field_name" $assign_str_lvalue "field" $field "native" $native }}
+        var value []{{ goType $scope $field.Type }}
+    {{- else }}
+        var value {{ goType $scope $field.Type }}
     {{- end }}
-    
-    {{- template "decode_compound_parameters.go.tmpl" dict "pkg" $scope "field" $field "field_name" $assign_str_lvalue }}
+    {{- $assign_str_lvalue = "value" }}
+    {{- $assign_str_rvalue = "value" }}
+{{- end }}
 
-    {{- if $field.Array }}
-        {{- if not $field.Array.IsPacked }}
-            // This array is implicitly packed, because its parent object is packed
-            {{ $field.Name }}ArrayProperties.IsPacked = true
-        {{- end }}
-        if err = {{ $field.Name }}ArrayProperties.UnmarshalZserio(r); err != nil {
-            return err
-        }
-        {{- if or $native.IsMarshaler $native.RequiresCast }}
-        {{- $element := "elem" }}
-        {{- if $native.IsMarshaler }}
-            {{- $element = "*elem" }}
-        {{- end }}
-        for _, elem := range {{ $field.Name }}ArrayProperties.RawArray {
-            {{ $assign_str_lvalue }} = append({{ $assign_str_lvalue }}, {{ if $native.RequiresCast }}{{ goType $scope $field.Type }}({{ $element }}){{ else }}{{ $element }}{{ end }})
-        }
-        {{- end }}
-    {{- else if eq $native.Type.Name "bool" }}
-        {{- if $native.RequiresCast }}
-            if tempValue, err := ztype.ReadBool(r); err != nil {
-                return err
-            } else {
-                {{ $assign_str_lvalue }} = ({{ goType $scope $field.Type }})(tempValue)
-            }
-        {{- else }}
-            if {{ $assign_str_lvalue }}, err = ztype.ReadBool(r); err != nil {
-                return err
-            }
-        {{- end }}
+{{- if not (eq $field.Alignment 0) }}
+    r.Align({{ $field.Alignment }})
+{{- end }}
 
-    {{- else if eq $native.Type.Name "extern" }}
-        if tempValue, err := ztype.ReadExtern(r); err == nil {
-            {{ $assign_str_lvalue }} = ({{ goType $scope $field.Type }})(tempValue)
-        } else {
-            return err
-        }
+{{- if $field.Array }}
+{{- template "array_init.go.tmpl" dict "pkg" $scope "field_name" $assign_str_lvalue "field" $field "native" $native }}
+{{- end }}
 
-    {{- else if eq $native.Type.Name "string" }}
-        if tempValue, err := ztype.ReadString(r); err == nil {
-            {{ $assign_str_lvalue }} = ({{ goType $scope $field.Type }})(tempValue)
-        } else {
-            return err
-        }
+{{- template "decode_compound_parameters.go.tmpl" dict "pkg" $scope "field" $field "field_name" $assign_str_lvalue }}
 
-    {{- else if $native.IsMarshaler }}
-        if err = {{ $assign_str_rvalue }}.UnmarshalZserioPacked(childrenNodes[{{ $index }}], r); err != nil {
-            return err
-        }
-
-
-    {{- else}}
-        if field{{ $field.Name }}Context, ok := childrenNodes[{{ $index }}].Context.(*ztype.DeltaContext[{{ goType $scope $native.Type }}]); !ok {
-            return errors.New("unknown context type")
-        } else {
-            traits := {{ template "instantiate_array_traits.go.tmpl" dict "pkg" $scope "type" $native.Type }}
-            if tempValue, err := field{{ $field.Name }}Context.Read(&traits, r); err == nil {
-                {{ $assign_str_lvalue }} = ({{ goType $scope $field.Type }})(tempValue)
-            } else {
-                return err
-            }
-        }
-    {{- end}}
-
-
-    {{- if $field.OptionalClause }}
+{{- if $field.Array }}
+    {{- if not $field.Array.IsPacked }}
+        // This array is implicitly packed, because its parent object is packed
+        {{ $field.Name }}ArrayProperties.IsPacked = true
+    {{- end }}
+    if err = {{ $field.Name }}ArrayProperties.UnmarshalZserio(r); err != nil {
+        return err
+    }
+    {{- if or $native.IsMarshaler $native.RequiresCast }}
+    {{- $element := "elem" }}
+    {{- if $native.IsMarshaler }}
+        {{- $element = "*elem" }}
+    {{- end }}
+    for _, elem := range {{ $field.Name }}ArrayProperties.RawArray {
+        {{ $assign_str_lvalue }} = append({{ $assign_str_lvalue }}, {{ if $native.RequiresCast }}{{ goType $scope $field.Type }}({{ $element }}){{ else }}{{ $element }}{{ end }})
     }
     {{- end }}
+{{- else if eq $native.Type.Name "bool" }}
+    {{- if $native.RequiresCast }}
+        if tempValue, err := ztype.ReadBool(r); err != nil {
+            return err
+        } else {
+            {{ $assign_str_lvalue }} = ({{ goType $scope $field.Type }})(tempValue)
+        }
+    {{- else }}
+        if {{ $assign_str_lvalue }}, err = ztype.ReadBool(r); err != nil {
+            return err
+        }
+    {{- end }}
 
-{{- end }}{{/* if $field.IsOptional */}}
+{{- else if eq $native.Type.Name "extern" }}
+    if tempValue, err := ztype.ReadExtern(r); err == nil {
+        {{ $assign_str_lvalue }} = ({{ goType $scope $field.Type }})(tempValue)
+    } else {
+        return err
+    }
+
+{{- else if eq $native.Type.Name "string" }}
+    if tempValue, err := ztype.ReadString(r); err == nil {
+        {{ $assign_str_lvalue }} = ({{ goType $scope $field.Type }})(tempValue)
+    } else {
+        return err
+    }
+
+{{- else if $native.IsMarshaler }}
+    if err = {{ $assign_str_rvalue }}.UnmarshalZserioPacked(childrenNodes[{{ $index }}], r); err != nil {
+        return err
+    }
+
+
+{{- else}}
+    if field{{ $field.Name }}Context, ok := childrenNodes[{{ $index }}].Context.(*ztype.DeltaContext[{{ goType $scope $native.Type }}]); !ok {
+        return errors.New("unknown context type")
+    } else {
+        traits := {{ template "instantiate_array_traits.go.tmpl" dict "pkg" $scope "type" $native.Type }}
+        if tempValue, err := field{{ $field.Name }}Context.Read(&traits, r); err == nil {
+            {{ $assign_str_lvalue }} = ({{ goType $scope $field.Type }})(tempValue)
+        } else {
+            return err
+        }
+    }
+{{- end}}
+
+{{- if $field.IsOptional}}
+        v.{{ $field.Name }} = &value
+    } else {
+        v.{{ $field.Name }} = nil
+    }
+{{- end }}
+
+{{- if $field.OptionalClause }}
+}
+{{- end }}

--- a/internal/generator/templates/packing_context_encode.go.tmpl
+++ b/internal/generator/templates/packing_context_encode.go.tmpl
@@ -21,80 +21,86 @@
     {{- end }}
 {{- end }}
 
+{{- if $field.OptionalClause }}
+    if {{ goExpression $scope $field.OptionalClause }} {
+{{- end }}
 
 {{- if $field.IsOptional}}
-    // this field is optional, and therefore uses the standard mershaling
-    {{- template "encode.go.tmpl" dict "pkg" $scope "field" $field }}
-{{- else }}
-    {{- if $field.OptionalClause }}
-        if {{ goExpression $scope $field.OptionalClause }} {
-    {{- end }}
-    {{- if not (eq $field.Alignment 0) }}
-        if _, err := w.Align({{ $field.Alignment }}); err != nil {
-            return err
-        }
-    {{- end }}
+    if err = ztype.WriteBool(w, v.{{ $field.Name }} != nil); err != nil {
+        return err
+    }
+    if v.{{ $field.Name }} != nil {
+{{- end }}
 
-    {{- if $field.Array }}
-        {{- template "array_init.go.tmpl" dict "pkg" $scope "field_name" $field_name "field" $field "native" $native }}
-        {{- if $field.Array.Length }}
-            if len({{ $field_name }}) != int({{ goExpression $scope $field.Array.Length }}) {
-                return errors.New("array size does not match!")
-            }
-        {{- end }}
-    {{- end }}
-    
-    {{- template "encode_compound_parameters.go.tmpl" dict "pkg" $scope "field" $field "field_name" $field_name }}
-    {{- if $field.Array }}
-        {{- if not $field.Array.IsPacked }}
-            // This array is implicitly packed, because its parent object is packed
-            {{ $field.Name }}ArrayProperties.IsPacked = true
-        {{- end }}
-        {{- if $native.IsMarshaler }}
-        for index, _ := range {{ $field_name }} {
-            {{ $field.Name }}ArrayProperties.RawArray = append({{ $field.Name }}ArrayProperties.RawArray, {{if $native.RequiresCast }}(*{{ goType $scope $native.Type }})(&{{ $field_name }}[index]){{ else }}&{{ $field_name }}[index]{{ end }})
-        }
-        {{- else if $native.RequiresCast }}
-        for _, element := range {{ $field_name }} {
-            {{ $field.Name }}ArrayProperties.RawArray = append({{ $field.Name }}ArrayProperties.RawArray, {{ goType $scope $native.Type }}(element))
-        }
-        {{- end }}
-        if err = {{ $field.Name }}ArrayProperties.MarshalZserio(w); err != nil {
-            return err
-        }
+{{- if not (eq $field.Alignment 0) }}
+    if _, err := w.Align({{ $field.Alignment }}); err != nil {
+        return err
+    }
+{{- end }}
 
-    {{- else if eq $native.Type.Name "bool" }}
-        if err := ztype.WriteBool(w, {{ if $native.RequiresCast }}bool({{end}}{{ $field_name }}{{ if $native.RequiresCast }}){{end}}); err != nil {
-            return err
-        } 
-
-    {{- else if eq $native.Type.Name "extern" }}
-        if err := ztype.WriteExtern(w, {{ $field_name }}); err != nil {
-            return err
-        }
-
-    {{- else if eq $native.Type.Name "string" }}
-        if err := ztype.WriteString(w, {{ $field_name }}); err != nil {
-            return err
-        }
-
-    {{- else if $native.IsMarshaler }}
-        if err := {{ $field_name }}.MarshalZserioPacked(childrenNodes[{{ $index }}], w); err != nil {
-            return err
-        }
-
-
-    {{- else}}
-        if field{{ $field.Name }}Context, ok := childrenNodes[{{ $index }}].Context.(*ztype.DeltaContext[{{ goType $scope $native.Type }}]); !ok {
-            return errors.New("unknown context type")
-        } else {
-            if err := field{{ $field.Name }}Context.Write(&{{ template "instantiate_array_traits.go.tmpl" dict "pkg" $scope "type" $native.Type }}, w, {{ goType $scope $native.Type }}({{ $field_name }})); err != nil {
-                return err
-            }
-        }
-    {{- end}}
-    
-    {{- if $field.OptionalClause}}
+{{- if $field.Array }}
+    {{- template "array_init.go.tmpl" dict "pkg" $scope "field_name" $field_name "field" $field "native" $native }}
+    {{- if $field.Array.Length }}
+        if len({{ $field_name }}) != int({{ goExpression $scope $field.Array.Length }}) {
+            return errors.New("array size does not match!")
         }
     {{- end }}
-{{- end }}{{/* $field.IsOptional */}}
+{{- end }}
+
+{{- template "encode_compound_parameters.go.tmpl" dict "pkg" $scope "field" $field "field_name" $field_name }}
+{{- if $field.Array }}
+    {{- if not $field.Array.IsPacked }}
+        // This array is implicitly packed, because its parent object is packed
+        {{ $field.Name }}ArrayProperties.IsPacked = true
+    {{- end }}
+    {{- if $native.IsMarshaler }}
+    for index, _ := range {{ $field_name }} {
+        {{ $field.Name }}ArrayProperties.RawArray = append({{ $field.Name }}ArrayProperties.RawArray, {{if $native.RequiresCast }}(*{{ goType $scope $native.Type }})(&{{ $field_name }}[index]){{ else }}&{{ $field_name }}[index]{{ end }})
+    }
+    {{- else if $native.RequiresCast }}
+    for _, element := range {{ $field_name }} {
+        {{ $field.Name }}ArrayProperties.RawArray = append({{ $field.Name }}ArrayProperties.RawArray, {{ goType $scope $native.Type }}(element))
+    }
+    {{- end }}
+    if err = {{ $field.Name }}ArrayProperties.MarshalZserio(w); err != nil {
+        return err
+    }
+
+{{- else if eq $native.Type.Name "bool" }}
+    if err := ztype.WriteBool(w, {{ if $native.RequiresCast }}bool({{end}}{{ $field_name }}{{ if $native.RequiresCast }}){{end}}); err != nil {
+        return err
+    } 
+
+{{- else if eq $native.Type.Name "extern" }}
+    if err := ztype.WriteExtern(w, {{ $field_name }}); err != nil {
+        return err
+    }
+
+{{- else if eq $native.Type.Name "string" }}
+    if err := ztype.WriteString(w, {{ $field_name }}); err != nil {
+        return err
+    }
+
+{{- else if $native.IsMarshaler }}
+    if err := {{ $field_name }}.MarshalZserioPacked(childrenNodes[{{ $index }}], w); err != nil {
+        return err
+    }
+
+
+{{- else}}
+    if field{{ $field.Name }}Context, ok := childrenNodes[{{ $index }}].Context.(*ztype.DeltaContext[{{ goType $scope $native.Type }}]); !ok {
+        return errors.New("unknown context type")
+    } else {
+        if err := field{{ $field.Name }}Context.Write(&{{ template "instantiate_array_traits.go.tmpl" dict "pkg" $scope "type" $native.Type }}, w, {{ goType $scope $native.Type }}({{ $field_name }})); err != nil {
+            return err
+        }
+    }
+{{- end}}
+
+{{- if $field.IsOptional}}
+    }
+{{- end }}
+
+{{- if $field.OptionalClause}}
+    }
+{{- end }}

--- a/internal/generator/templates/packing_context_init.go.tmpl
+++ b/internal/generator/templates/packing_context_init.go.tmpl
@@ -18,10 +18,14 @@
 {{- end }}
 
 
-{{- if and (not $field.Array) (not $field.IsOptional) (not (eq $native.Type.Name "bool")) (not (eq $native.Type.Name "string")) (not (eq $native.Type.Name "extern")) }}
+{{- if and (not $field.Array) (not (eq $native.Type.Name "bool")) (not (eq $native.Type.Name "string")) (not (eq $native.Type.Name "extern")) }}
     {{- if $field.OptionalClause }}
         if {{ goExpression $scope $field.OptionalClause }} {
     {{- end }}
+    {{- if $field.IsOptional}}
+        if v.{{ $field.Name }} != nil {
+    {{- end }}
+
     {{- template "decode_compound_parameters.go.tmpl" dict "pkg" $scope "field" $field "field_name" $field_name }}
     {{- if $native.IsMarshaler }}
         if err := {{ $field_name }}.ZserioInitPackingContext(childrenNodes[{{ $index }}]); err != nil {
@@ -35,6 +39,10 @@
 
             traits := {{ template "instantiate_array_traits.go.tmpl" dict "pkg" $scope "type" $native.Type }}
             field{{ $field.Name }}Context.Init(&traits, {{ goType $scope $native.Type }}({{ $field_name }}))
+        }
+    {{- end }}
+
+    {{- if $field.IsOptional}}
         }
     {{- end }}
     {{- if $field.OptionalClause }}


### PR DESCRIPTION
- Previously, if a struct was written in a packed array, optional
  field were not written packed, but unpacked.
- This commit changes the behavior so that optional fields in structs
  residing in arrays now also use the packed variants for de/encoding.