### PR TITLE
Fix passing of parameters to parameterized compound arrays

### DIFF
--- a/internal/generator/templates/encode_compound_parameters.go.tmpl
+++ b/internal/generator/templates/encode_compound_parameters.go.tmpl
@@ -5,8 +5,8 @@
 
 {{- if $field.Type.TypeArguments }}
     {{- if $field.Array }}
-        for _, element := range {{ $field_name }} {
-        {{- $field_name = "element" }}
+        for index, _ := range {{ $field_name }} {
+        {{- $field_name = printf "%s[index]" $field_name }}
     {{- end }}
     {{- $type_parameter := getTypeParameter $scope $field.Type }}
     {{- range $i, $argument := $field.Type.TypeArguments }}


### PR DESCRIPTION
- If a compound type (e.g struct) contains an array of another compound
  type, and this inner type is parameterized, then there is a bug that
  the parameters are not correctly passed to the inner compound type.
- The bug originated in the code which passes the parameters from the
  outer compound type to the inner compound type. In a for loop, the
  parameters are copied over.
- Before this fix, the parameters were copied to the second variable "b"
  in the for loop (for a, b := range ...). Since this variable was just
  a copy, the original array remained unchanged, effectively making
  this part of code useless.
- This bugfix fixes this issue by using the index, and assign the parameters
  directly in the array.