### PR TITLE
Fix the Number of bits used for packing delta-encoded arrays

### DIFF
--- a/ztype/varuint_encode.go
+++ b/ztype/varuint_encode.go
@@ -110,7 +110,16 @@ func UnsignedBitSize(v uint64, maxBytes int) (int, error) {
 	}
 }
 
-// NumBits returns the exact number of bits of an unsigned integer.
+// NumBits returns the exact number of bits needed to represent an unsigned
+// integer in zserio, considering the fact that 0 is not counted, due to the
+// zserio encoding.
 func NumBits(v uint64) int {
-	return bits.Len64(v)
+	if v == 0 {
+		return 0
+	}
+	if v == 1 {
+		return 1
+	}
+	// note that we subtract -1 here, because we will never encode a 0
+	return bits.Len64(v - 1)
 }

--- a/ztype/varuint_encode_test.go
+++ b/ztype/varuint_encode_test.go
@@ -407,9 +407,11 @@ func TestNumBits(t *testing.T) {
 		expected int
 		value    uint64
 	}{
-		"empty":  {0, 0},
-		"one":    {1, 1},
-		"random": {9, 264},
+		"empty":         {0, 0},
+		"one":           {1, 1},
+		"two":           {1, 2},
+		"random":        {9, 264},
+		"byte-boundary": {7, 128},
 	}
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {


### PR DESCRIPTION
- this was a fun bug to find: it would only occur when trying to encode
  numbers exactly located at the byte boundary (e.g. 64, 128, 256, etc).
  This is because due to the effort of zserio to never encode a 0 when
  not necessary, and therefore you don't need to think about the first
  number.
- This fix was implemented after some debugging, and comparing go-zserio
  with the reference implementation.