### PR TITLE
Fix Packing and Unpacking of Float Arrays

### DIFF
--- a/internal/ast/package.go
+++ b/internal/ast/package.go
@@ -150,17 +150,7 @@ func (p *Package) GoArrayTraits(t *TypeReference) (string, error) {
 		return p.GoArrayTraits(n.Type)
 	case *Subtype:
 		return p.GoArrayTraits(n.Type)
-	case *InstantiateType:
-		return objArrayTraitsStr, nil
-	case *Struct:
-		return objArrayTraitsStr, nil
-	case *Enum:
-		return objArrayTraitsStr, nil
-	case *Union:
-		return objArrayTraitsStr, nil
-	case *BitmaskType:
-		return objArrayTraitsStr, nil
-	case *Choice:
+	case *InstantiateType, *Struct, *Enum, *Union, *BitmaskType, *Choice:
 		return objArrayTraitsStr, nil
 	default:
 		return "", fmt.Errorf("%w: %s", ErrUnknownType, t.Name)
@@ -190,19 +180,11 @@ func (p *Package) IsDeltaPackable(t *TypeReference) (bool, error) {
 		return p.IsDeltaPackable(n.Type)
 	case *InstantiateType:
 		return p.IsDeltaPackable(n.Type)
-	case *Struct:
+	case *Struct, *Union, *Choice:
 		// compound types have their own packed marshaling function
 		return false, nil
-	case *Enum:
+	case *Enum, *BitmaskType:
 		return true, nil
-	case *Union:
-		// compound types have their own packed marshaling function
-		return false, nil
-	case *BitmaskType:
-		return true, nil
-	case *Choice:
-		// compound types have their own packed marshaling function
-		return false, nil
 	default:
 		return false, fmt.Errorf("%w: %s", ErrUnknownType, t.Name)
 	}

--- a/internal/generator/funcs.go
+++ b/internal/generator/funcs.go
@@ -8,6 +8,10 @@ import (
 	"github.com/woven-planet/go-zserio/internal/ast"
 )
 
+func IsDeltaPackable(scope ast.Scope, typ *ast.TypeReference) (bool, error) {
+	return scope.IsDeltaPackable(typ)
+}
+
 func GoType(scope ast.Scope, typ *ast.TypeReference) (string, error) {
 	return scope.GoType(typ)
 }

--- a/internal/generator/templates.go
+++ b/internal/generator/templates.go
@@ -15,6 +15,7 @@ var templates *template.Template
 func init() {
 	var err error
 	funcs := map[string]any{
+		"isDeltaPackable":  IsDeltaPackable,
 		"goType":           GoType,
 		"goPackageName":    GoPackageName,
 		"goGetAllImports":  GoGetAllImports,

--- a/internal/generator/templates/array_init.go.tmpl
+++ b/internal/generator/templates/array_init.go.tmpl
@@ -7,18 +7,6 @@
 {{ $field.Name }}ArrayProperties := ztype.Array[{{if $native.IsMarshaler }}*{{ end }}{{ goType $scope $native.Type }}, {{ template "array_traits_type.go.tmpl" dict "pkg" $scope "type" $native.Type }}]{}
 {{ $field.Name }}ArrayProperties.ArrayTraits = {{ template "instantiate_array_traits.go.tmpl" dict "pkg" $scope "type" $native.Type }}
 
-{{- if $native.IsMarshaler }}
-    // the field type is a zserio object, which requires a list of struct 
-    // pointers.
-    {{ $field.Name }}ArrayProperties.RawArray = make([]*{{ goType $scope $native.Type }}, 0)
-{{- else if $native.RequiresCast }}
-    // the field type is a subtype, which requires to cast the subtype array
-    // to the basic type
-    {{ $field.Name }}ArrayProperties.RawArray = make([]{{ goType $scope $native.Type }}, 0)
-{{- else }}
-    {{ $field.Name }}ArrayProperties.RawArray = {{ $field_name }}
-{{- end }}
-
 {{- if $field.Array.IsPacked }}
     {{ $field.Name }}ArrayProperties.IsPacked = true
 {{- end }}

--- a/internal/generator/templates/decode.go.tmpl
+++ b/internal/generator/templates/decode.go.tmpl
@@ -65,13 +65,15 @@
     }
     {{- if $field.Array }}
         {{- if or $native.IsMarshaler $native.RequiresCast }}
-        {{- $element := "elem" }}
-        {{- if $native.IsMarshaler }}
-            {{- $element = "*elem" }}
-        {{- end }}
-        for _, elem := range {{ $field.Name }}ArrayProperties.RawArray {
-            {{ $assign_str_lvalue }} = append({{ $assign_str_lvalue }}, {{ if $native.RequiresCast }}{{ goType $scope $field.Type }}({{ $element }}){{ else }}{{ $element }}{{ end }})
-        }
+            {{- $element := "elem" }}
+            {{- if $native.IsMarshaler }}
+                {{- $element = "*elem" }}
+            {{- end }}
+            for _, elem := range {{ $field.Name }}ArrayProperties.RawArray {
+                {{ $assign_str_lvalue }} = append({{ $assign_str_lvalue }}, {{ if $native.RequiresCast }}{{ goType $scope $field.Type }}({{ $element }}){{ else }}{{ $element }}{{ end }})
+            }
+        {{- else }}
+            {{ $assign_str_lvalue }} = {{ $field.Name }}ArrayProperties.RawArray
         {{- end }}
     {{- end }}
 {{- end}}

--- a/internal/generator/templates/encode.go.tmpl
+++ b/internal/generator/templates/encode.go.tmpl
@@ -44,13 +44,15 @@
         }
     {{- end }}
     {{- if $native.IsMarshaler }}
-    for index, _ := range {{ $field_name }} {
-        {{ $field.Name }}ArrayProperties.RawArray = append({{ $field.Name }}ArrayProperties.RawArray, {{if $native.RequiresCast }}(*{{ goType $scope $native.Type }})(&{{ $field_name }}[index]){{ else }}&{{ $field_name }}[index]{{ end }})
-    }
+        for index, _ := range {{ $field_name }} {
+            {{ $field.Name }}ArrayProperties.RawArray = append({{ $field.Name }}ArrayProperties.RawArray, {{if $native.RequiresCast }}(*{{ goType $scope $native.Type }})(&{{ $field_name }}[index]){{ else }}&{{ $field_name }}[index]{{ end }})
+        }
     {{- else if $native.RequiresCast }}
-    for _, element := range {{ $field_name }} {
-        {{ $field.Name }}ArrayProperties.RawArray = append({{ $field.Name }}ArrayProperties.RawArray, {{ goType $scope $native.Type }}(element))
-    }
+        for _, element := range {{ $field_name }} {
+            {{ $field.Name }}ArrayProperties.RawArray = append({{ $field.Name }}ArrayProperties.RawArray, {{ goType $scope $native.Type }}(element))
+        }
+    {{- else }}
+        {{ $field.Name }}ArrayProperties.RawArray = {{ $field_name }}
     {{- end }}
     {{- $field_name = printf "%sArrayProperties" $field.Name }}
 {{- end }}

--- a/internal/generator/templates/packing_context_bitsize.go.tmpl
+++ b/internal/generator/templates/packing_context_bitsize.go.tmpl
@@ -44,18 +44,15 @@
     } else {
     endBitPosition += delta
     }
-{{- else if or $field.IsOptional (eq $native.Type.Name "bool") (eq $native.Type.Name "string") (eq $native.Type.Name "extern") }}
-    {{/* These fields use the standard packing */}}
-    {{- template "builtin_bitsizeof.go.tmpl" dict "pkg" $scope "name" $field_name "native" $native "isarray" $field.Array }}
 
-{{- else }}
-    {{- if $native.IsMarshaler }}
-        if delta, err := {{ $field_name }}.ZserioBitSizePacked(childrenNodes[{{ $index }}], endBitPosition); err != nil {
-            return 0, err
-        } else {
-            endBitPosition += delta
-        } 
-    {{- else }}
+{{- else  if $native.IsMarshaler }}
+    if delta, err := {{ $field_name }}.ZserioBitSizePacked(childrenNodes[{{ $index }}], endBitPosition); err != nil {
+        return 0, err
+    } else {
+        endBitPosition += delta
+    }
+
+{{- else if isDeltaPackable $scope $native.Type }}
     if field{{ $field.Name }}Context, ok := childrenNodes[{{ $index }}].Context.(*ztype.DeltaContext[{{ goType $scope $native.Type }}]); !ok {
         return 0, errors.New("invalid packing context")
     } else {
@@ -65,7 +62,12 @@
             endBitPosition += delta
         }
     }
-    {{- end }}
+
+
+{{- else }}
+    {{/* These fields use the standard packing */}}
+    {{- template "builtin_bitsizeof.go.tmpl" dict "pkg" $scope "name" $field_name "native" $native "isarray" $field.Array }}
+
 {{- end }}
 {{- if $field.IsOptional}}
     }

--- a/internal/generator/templates/packing_context_create.go.tmpl
+++ b/internal/generator/templates/packing_context_create.go.tmpl
@@ -5,14 +5,22 @@
 
 field{{ $field.Name }}Node := &zserio.PackingContextNode{}
 contextNode.AddChild(field{{ $field.Name }}Node)
-{{- if and (not $field.Array) (not (eq $native.Type.Name "bool")) (not (eq $native.Type.Name "string")) (not (eq $native.Type.Name "extern")) }}
+{{- if not $field.Array }}
     {{- if $native.IsMarshaler }}
+        {{- /* The if IsMarshaler must come before checking if the type is 
+        isDeltaPackable, because some marshable types, such es Enums, can also be 
+        delta packed */}}
+        // the field is a marshalable type, let the type itself decide if a delta
+        // context is needed
         var field{{ $field.Name }}Ptr *{{ goType $scope $native.Type }}
         if err := field{{ $field.Name }}Ptr.ZserioCreatePackingContext(field{{ $field.Name }}Node); err != nil {
             return err
         }
-    {{- else }}
-        // The field is not a marshalable type, therefore create use a delta context.
+       
+    {{- else if isDeltaPackable $scope $native.Type }}
+        // The field can be directly delta packed, therefore create a delta context
         field{{ $field.Name }}Node.Context = &ztype.DeltaContext[{{ goType $scope $native.Type }}]{}
+
+ 
     {{- end }}
 {{- end }}

--- a/internal/generator/templates/packing_context_decode.go.tmpl
+++ b/internal/generator/templates/packing_context_decode.go.tmpl
@@ -61,13 +61,15 @@
         return err
     }
     {{- if or $native.IsMarshaler $native.RequiresCast }}
-    {{- $element := "elem" }}
-    {{- if $native.IsMarshaler }}
-        {{- $element = "*elem" }}
-    {{- end }}
-    for _, elem := range {{ $field.Name }}ArrayProperties.RawArray {
-        {{ $assign_str_lvalue }} = append({{ $assign_str_lvalue }}, {{ if $native.RequiresCast }}{{ goType $scope $field.Type }}({{ $element }}){{ else }}{{ $element }}{{ end }})
-    }
+        {{- $element := "elem" }}
+        {{- if $native.IsMarshaler }}
+            {{- $element = "*elem" }}
+        {{- end }}
+        for _, elem := range {{ $field.Name }}ArrayProperties.RawArray {
+            {{ $assign_str_lvalue }} = append({{ $assign_str_lvalue }}, {{ if $native.RequiresCast }}{{ goType $scope $field.Type }}({{ $element }}){{ else }}{{ $element }}{{ end }})
+        }
+    {{- else }}
+        {{ $assign_str_lvalue }} = {{ $field.Name }}ArrayProperties.RawArray
     {{- end }}
 
 {{- else if $native.IsMarshaler }}

--- a/internal/generator/templates/packing_context_decode.go.tmpl
+++ b/internal/generator/templates/packing_context_decode.go.tmpl
@@ -69,40 +69,13 @@
         {{ $assign_str_lvalue }} = append({{ $assign_str_lvalue }}, {{ if $native.RequiresCast }}{{ goType $scope $field.Type }}({{ $element }}){{ else }}{{ $element }}{{ end }})
     }
     {{- end }}
-{{- else if eq $native.Type.Name "bool" }}
-    {{- if $native.RequiresCast }}
-        if tempValue, err := ztype.ReadBool(r); err != nil {
-            return err
-        } else {
-            {{ $assign_str_lvalue }} = ({{ goType $scope $field.Type }})(tempValue)
-        }
-    {{- else }}
-        if {{ $assign_str_lvalue }}, err = ztype.ReadBool(r); err != nil {
-            return err
-        }
-    {{- end }}
-
-{{- else if eq $native.Type.Name "extern" }}
-    if tempValue, err := ztype.ReadExtern(r); err == nil {
-        {{ $assign_str_lvalue }} = ({{ goType $scope $field.Type }})(tempValue)
-    } else {
-        return err
-    }
-
-{{- else if eq $native.Type.Name "string" }}
-    if tempValue, err := ztype.ReadString(r); err == nil {
-        {{ $assign_str_lvalue }} = ({{ goType $scope $field.Type }})(tempValue)
-    } else {
-        return err
-    }
 
 {{- else if $native.IsMarshaler }}
     if err = {{ $assign_str_rvalue }}.UnmarshalZserioPacked(childrenNodes[{{ $index }}], r); err != nil {
         return err
     }
-
-
-{{- else}}
+    
+{{- else if isDeltaPackable $scope $native.Type }}
     if field{{ $field.Name }}Context, ok := childrenNodes[{{ $index }}].Context.(*ztype.DeltaContext[{{ goType $scope $native.Type }}]); !ok {
         return errors.New("unknown context type")
     } else {
@@ -113,6 +86,14 @@
             return err
         }
     }
+
+{{- else }}
+    if tempValue, err := ztype.Read{{ title $native.Type.Name }}(r); err == nil {
+        {{ $assign_str_lvalue }} = ({{ goType $scope $field.Type }})(tempValue)
+    } else {
+        return err
+    }
+
 {{- end}}
 
 {{- if $field.IsOptional}}

--- a/internal/generator/templates/packing_context_encode.go.tmpl
+++ b/internal/generator/templates/packing_context_encode.go.tmpl
@@ -54,13 +54,15 @@
         {{ $field.Name }}ArrayProperties.IsPacked = true
     {{- end }}
     {{- if $native.IsMarshaler }}
-    for index, _ := range {{ $field_name }} {
-        {{ $field.Name }}ArrayProperties.RawArray = append({{ $field.Name }}ArrayProperties.RawArray, {{if $native.RequiresCast }}(*{{ goType $scope $native.Type }})(&{{ $field_name }}[index]){{ else }}&{{ $field_name }}[index]{{ end }})
-    }
+        for index, _ := range {{ $field_name }} {
+            {{ $field.Name }}ArrayProperties.RawArray = append({{ $field.Name }}ArrayProperties.RawArray, {{if $native.RequiresCast }}(*{{ goType $scope $native.Type }})(&{{ $field_name }}[index]){{ else }}&{{ $field_name }}[index]{{ end }})
+        }
     {{- else if $native.RequiresCast }}
-    for _, element := range {{ $field_name }} {
-        {{ $field.Name }}ArrayProperties.RawArray = append({{ $field.Name }}ArrayProperties.RawArray, {{ goType $scope $native.Type }}(element))
-    }
+        for _, element := range {{ $field_name }} {
+            {{ $field.Name }}ArrayProperties.RawArray = append({{ $field.Name }}ArrayProperties.RawArray, {{ goType $scope $native.Type }}(element))
+        }
+    {{- else }}
+        {{ $field.Name }}ArrayProperties.RawArray = {{ $field_name }}
     {{- end }}
     if err = {{ $field.Name }}ArrayProperties.MarshalZserio(w); err != nil {
         return err

--- a/internal/generator/templates/packing_context_encode.go.tmpl
+++ b/internal/generator/templates/packing_context_encode.go.tmpl
@@ -66,28 +66,13 @@
         return err
     }
 
-{{- else if eq $native.Type.Name "bool" }}
-    if err := ztype.WriteBool(w, {{ if $native.RequiresCast }}bool({{end}}{{ $field_name }}{{ if $native.RequiresCast }}){{end}}); err != nil {
-        return err
-    } 
-
-{{- else if eq $native.Type.Name "extern" }}
-    if err := ztype.WriteExtern(w, {{ $field_name }}); err != nil {
-        return err
-    }
-
-{{- else if eq $native.Type.Name "string" }}
-    if err := ztype.WriteString(w, {{ $field_name }}); err != nil {
-        return err
-    }
-
 {{- else if $native.IsMarshaler }}
     if err := {{ $field_name }}.MarshalZserioPacked(childrenNodes[{{ $index }}], w); err != nil {
         return err
     }
 
 
-{{- else}}
+{{- else if isDeltaPackable $scope $native.Type }}
     if field{{ $field.Name }}Context, ok := childrenNodes[{{ $index }}].Context.(*ztype.DeltaContext[{{ goType $scope $native.Type }}]); !ok {
         return errors.New("unknown context type")
     } else {
@@ -95,6 +80,12 @@
             return err
         }
     }
+
+{{- else }}
+    if err := ztype.Write{{ title $native.Type.Name }}(w, {{ if $native.RequiresCast }}{{ goType $scope $native.Type }}({{end}}{{ $field_name }}{{ if $native.RequiresCast }}){{end}}); err != nil {
+        return err
+    } 
+
 {{- end}}
 
 {{- if $field.IsOptional}}

--- a/internal/generator/templates/packing_context_init.go.tmpl
+++ b/internal/generator/templates/packing_context_init.go.tmpl
@@ -18,7 +18,7 @@
 {{- end }}
 
 
-{{- if and (not $field.Array) (not (eq $native.Type.Name "bool")) (not (eq $native.Type.Name "string")) (not (eq $native.Type.Name "extern")) }}
+{{- if and (not $field.Array) (or ($native.IsMarshaler) (isDeltaPackable $scope $native.Type)) }}
     {{- if $field.OptionalClause }}
         if {{ goExpression $scope $field.OptionalClause }} {
     {{- end }}
@@ -31,7 +31,6 @@
         if err := {{ $field_name }}.ZserioInitPackingContext(childrenNodes[{{ $index }}]); err != nil {
             return err
         }
-
     {{- else }}
         if field{{ $field.Name }}Context, ok := childrenNodes[{{ $index }}].Context.(*ztype.DeltaContext[{{ goType $scope $native.Type }}]); !ok {
             return errors.New("unknown context type")

--- a/test/reference/data.py
+++ b/test/reference/data.py
@@ -54,5 +54,11 @@ def new():
     d.basic_choice = BasicChoice(d.choice_selector)
     d.basic_choice.has_a = 5
 
+    # The next test checks that float types are correctly stored in packed and
+    # nonpacked arrays
+    d.float_member = 23.5
+    for i in range(100):
+        d.float_array.append(float(i))
+
     d.foo = 42
     return d

--- a/test/reference/reference_test.go
+++ b/test/reference/reference_test.go
@@ -105,6 +105,12 @@ func want() testobject.TestObject {
 		HasA: 5,
 	}
 
+	// The next test checks that float types are correctly stored in arrays
+	d.FloatMember = 23.5
+	for i := 0; i < 100; i++ {
+		d.FloatArray = append(d.FloatArray, float64(i))
+	}
+
 	d.Foo = 42
 	return d
 }

--- a/testdata/reference_modules/testobject1/testobject.zs
+++ b/testdata/reference_modules/testobject1/testobject.zs
@@ -29,8 +29,11 @@ struct TestObject
     // This tests the correct type lookup if the choice selector type is enum
     SomeEnum choiceSelector;
     BasicChoice(choiceSelector) basicChoice;
-
-    // foo is just there to have something after an optional type
-    varint32 foo;
     
+    // test floats and array of floats
+    float32 floatMember;
+    float64 floatArray[100];
+
+    // foo is just there to have an easy to check value at the end of the byte stream
+    varint32 foo;
 };


### PR DESCRIPTION
- There is a bug in the current go-zserio implementation related to
  float arrays. go-zserio tries to delta-pack float arrays, while the
  reference implementation does not apply delta-packing for float
  arrays.
- This test case adds float field, float array fields, and packed float
  array fields to the test.
- The generation code is reworked, by adding a Go function "isDeltaPackable", which returns is a data type can be delta packed.
- This function is then used during code generation to generate the code for normal marshaling or delta packed marshaling.
- Additionally, the way arrays are copied before marshaling or after marshaling is also fixed:  this issue was found when trying to decode an array of plain types, which does not require casting. In this situation, Unmarshal() would end with an empty array, secretly swallowing the decoded data. This issue was not seen before, because all tests either use arrays of structs (= non basic type), or subtyped basic types (requires  casting).