### PR TITLE
Implement Packed Bitsize Calculation for Enums and Bitmasks

### DIFF
--- a/internal/generator/templates/bitmask.go.tmpl
+++ b/internal/generator/templates/bitmask.go.tmpl
@@ -78,9 +78,18 @@ func (v *{{ $bitmask.Name}}) ZserioCreatePackingContext(contextNode *zserio.Pack
 
 
 func (v *{{ $bitmask.Name}}) ZserioInitPackingContext(contextNode *zserio.PackingContextNode) error {
+  if !contextNode.HasContext() {
+    return errors.New("context node has no packing")
+  }
+  context, ok := contextNode.Context.(*ztype.DeltaContext[{{ goType $scope $native.Type }}])
+  if !ok {
+    return errors.New("unsupported packing context type")
+  }
+
+  traits := {{- template "instantiate_array_traits.go.tmpl" dict "pkg" $scope "type" $native.Type }}
+  context.Init(&traits, {{ goType $scope $native.Type }}(*v))
   return nil
 }
-
 
 func (v *{{ $bitmask.Name}}) UnmarshalZserioPacked(contextNode *zserio.PackingContextNode, r zserio.Reader) error {
   context, ok := contextNode.Context.(*ztype.DeltaContext[{{ goType $scope $native.Type }}])
@@ -112,5 +121,13 @@ func (v *{{ $bitmask.Name}}) ZserioInitializeOffsetsPacked(contextNode *zserio.P
 }
 
 func (v *{{ $bitmask.Name}}) ZserioBitSizePacked(contextNode *zserio.PackingContextNode, bitPosition int) (int, error) {
-  return 0, nil
+  context, ok := contextNode.Context.(*ztype.DeltaContext[{{ goType $scope $native.Type }}])
+  if !ok {
+      return 0, errors.New("invalid packing context")
+  }
+  delta, err := context.BitSizeOf(&{{ template "instantiate_array_traits.go.tmpl" dict "pkg" $scope "type" $native.Type }}, bitPosition, {{ goType $scope $native.Type }}(*v))
+  if err != nil {
+      return 0, err
+  }
+  return delta, nil
 }

--- a/internal/generator/templates/enum.go.tmpl
+++ b/internal/generator/templates/enum.go.tmpl
@@ -122,5 +122,13 @@ func (v *{{ $enum.Name}}) ZserioInitializeOffsetsPacked(contextNode *zserio.Pack
 }
 
 func (v *{{ $enum.Name}}) ZserioBitSizePacked(contextNode *zserio.PackingContextNode, bitPosition int) (int, error) {
-  return 0, nil
+  context, ok := contextNode.Context.(*ztype.DeltaContext[{{ goType $scope $native.Type }}])
+  if !ok {
+      return 0, errors.New("invalid packing context")
+  }
+  delta, err := context.BitSizeOf(&{{ template "instantiate_array_traits.go.tmpl" dict "pkg" $scope "type" $native.Type }}, bitPosition, {{ goType $scope $native.Type }}(*v))
+  if err != nil {
+      return 0, err
+  }
+  return delta, nil
 }


### PR DESCRIPTION
- This commit will implement the bitsize calculations for packed enums or
  bitmasks arrays.
- This feature is needed at the point when zserio decides if the
  array should be written packed or nonpacked. If the packed bitsize
  is larger than the unpacked bitsize, packing is not used.
- Before this commit, enums were always packed (because the packed
  bitsize was hardcoded to 0), while bitmasks were alwas unpacked
  (because the initialization of the packing context was not implemented
  yet).
- It is likely that the bitsize calculations might still be off at some
  point, especially when calculated on large structures with optional fields,
  arrays or choices, but this will be covered by test cases added in the
  future.