### PR TITLE
Only emit Scan() when SQL support is requested

### DIFF
--- a/internal/generator/templates/enum.go.tmpl
+++ b/internal/generator/templates/enum.go.tmpl
@@ -77,7 +77,6 @@ func (v {{ $enum.Name }}) String() string {
 func (v {{ $enum.Name}}) Value() (driver.Value, error) {
         return v.String(), nil
 }
-{{ end }}
 
 // Scan implements database.sql.Scanner
 func (i *{{ $enum.Name}}) Scan(src interface{}) error {
@@ -105,6 +104,7 @@ func (i *{{ $enum.Name}}) Scan(src interface{}) error {
         *i = val
         return nil
 }
+{{ end }}
 
 func (v *{{ $enum.Name}}) Clone() zserio.ZserioType {
   clone := *v

--- a/rules.bzl
+++ b/rules.bzl
@@ -57,7 +57,7 @@ def go_zserio_srcs(name, srcs, rootpackage, pkg = None, format = True, sql = Fal
         ],
     )
 
-def go_zserio_library(name, srcs, rootpackage, pkg, **kwargs):
+def go_zserio_library(name, srcs, rootpackage, pkg, sql = True, **kwargs):
     """go_zserio_library generates go source code and a go library.
 
     Args:
@@ -65,9 +65,10 @@ def go_zserio_library(name, srcs, rootpackage, pkg, **kwargs):
         srcs: Zserio source files.
         rootpackage: rootpackage for the zserio bindings.
         pkg: The package name to output.
+        sql: Should we generate SQL marshalling and unmarshalling interfaces? Default to False.
         **kwargs: Extra keyword arguments to be passed to the underlying go_library.
     """
-    go_zserio_srcs(name = name + "_gen", srcs = srcs, rootpackage = rootpackage, pkg = pkg)
+    go_zserio_srcs(name = name + "_gen", srcs = srcs, rootpackage = rootpackage, pkg = pkg, sql = sql)
     _go_library(
         name = name,
         srcs = [name + "_gen"],


### PR DESCRIPTION
The `Scan()` function is only used when parsing data from a SQL driver, so only emit it if SQL support code is requested.
