### PR TITLE
Fix an inifite loop in enum String

### DIFF
--- a/internal/generator/templates/enum.go.tmpl
+++ b/internal/generator/templates/enum.go.tmpl
@@ -69,7 +69,7 @@ func (v {{ $enum.Name }}) String() string {
     if name, found := _{{ $enum.Name }}Name[v]; found {
         return name
     }
-    return fmt.Sprintf("unknown<%v>", v)
+    return fmt.Sprintf("unknown(%v)", {{ goType $scope $enum.Type }}(v))
 }
 
 {{ if $options.EmitSQLSupport }}

--- a/test/enum_test.go
+++ b/test/enum_test.go
@@ -28,3 +28,26 @@ func TestSqlRoundtrip(t *testing.T) {
 		assert.Equal(t, want, got)
 	}
 }
+
+func TestStringer(t *testing.T) {
+	t.Parallel()
+	tests := map[string]struct {
+		input types.SomeEnum
+		want  string
+	}{
+		"known-value": {
+			input: types.SomeEnumATTR_A,
+			want:  "ATTR_A",
+		},
+		"unknown-value": {
+			input: types.SomeEnum(-1),
+			want:  "unknown(-1)",
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := tt.input.String()
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/testdata/reference_modules/core/types.zs
+++ b/testdata/reference_modules/core/types.zs
@@ -38,7 +38,7 @@ struct ValueWrapper(int32 parameter)
 // SomeEnum defines some values
 enum int32 SomeEnum
 {
-    ATRR_A,
+    ATTR_A,
     ATTR_B,
     ATTR_C,
     HAS_A
@@ -56,7 +56,7 @@ enum int32 SomeOtherEnum
 
 choice BasicChoice(SomeEnum type) on type
 {
-    case ATRR_A: int32 fieldA;
+    case ATTR_A: int32 fieldA;
     case ATTR_B: int64 fieldB;
     case SomeEnum.ATTR_C: int8 fieldC;
 


### PR DESCRIPTION
When an enum has an unknown value String() returns a string with the underlying value. Unfortunately this could trigger infinite recursion.