### PR TITLE
Use CamelCase for enum values

### DIFF
--- a/internal/ast/BUILD.bazel
+++ b/internal/ast/BUILD.bazel
@@ -18,12 +18,18 @@ go_library(
     ],
     importpath = "github.com/woven-planet/go-zserio/internal/ast",
     visibility = ["//:__subpackages__"],
-    deps = ["//internal/parser"],
+    deps = [
+        "//internal/parser",
+        "@com_github_iancoleman_strcase//:strcase",
+    ],
 )
 
 go_test(
     name = "ast_test",
-    srcs = ["expression_test.go"],
+    srcs = [
+        "enum_test.go",
+        "expression_test.go",
+    ],
     deps = [
         ":ast",
         "//internal/parser",

--- a/internal/ast/enum.go
+++ b/internal/ast/enum.go
@@ -1,6 +1,11 @@
 package ast
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+
+	"github.com/iancoleman/strcase"
+)
 
 type MissingEnumValue struct {
 	Name string
@@ -15,6 +20,12 @@ type Enum struct {
 	Comment string
 	Items   []*EnumItem
 	Type    *TypeReference
+}
+
+func (e *Enum) AddItem(i *EnumItem) *EnumItem {
+	i.enum = e
+	e.Items = append(e.Items, i)
+	return i
 }
 
 func (e *Enum) Evaluate(scope *Package) error {
@@ -48,5 +59,10 @@ func (e *Enum) Evaluate(scope *Package) error {
 type EnumItem struct {
 	Name    string
 	Comment string
+	enum    *Enum
 	*Expression
+}
+
+func (e EnumItem) GoName() string {
+	return e.enum.Name + strcase.ToCamel(strings.ToLower(e.Name))
 }

--- a/internal/ast/enum_test.go
+++ b/internal/ast/enum_test.go
@@ -1,0 +1,31 @@
+package ast_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/woven-planet/go-zserio/internal/ast"
+)
+
+func TestEnumGoName(t *testing.T) {
+	tests := map[string]struct {
+		item *ast.EnumItem
+		want string
+	}{
+		"basic-uppercase": {
+			item: (&ast.Enum{Name: "Topping"}).AddItem(&ast.EnumItem{Name: "PINEAPPLE"}),
+			want: "ToppingPineapple",
+		},
+		"snake-uppercase": {
+			item: (&ast.Enum{Name: "Topping"}).AddItem(&ast.EnumItem{Name: "GREEN_PEPPER"}),
+			want: "ToppingGreenPepper",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.item.GoName())
+		})
+	}
+}

--- a/internal/generator/expression.go
+++ b/internal/generator/expression.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/iancoleman/strcase"
+
 	"github.com/woven-planet/go-zserio/internal/ast"
 	"github.com/woven-planet/go-zserio/internal/parser"
 )
@@ -49,7 +51,7 @@ func dotOperatorToGoString(scope ast.Scope, expression *ast.Expression) string {
 	// constant, which is Enum name, followed by the Enum value.
 	// The same is valid for bitmasks.
 	if expression.Operand1.ResultType == ast.ExpressionTypeEnum {
-		return leftText + rightText
+		return leftText + strcase.ToCamel(strings.ToLower(expression.Operand2.Text))
 	} else if expression.Operand1.ResultType == ast.ExpressionTypeBitmask {
 		return leftText + rightText
 	}

--- a/internal/generator/templates/enum.go.tmpl
+++ b/internal/generator/templates/enum.go.tmpl
@@ -10,7 +10,7 @@ const (
     {{- if $item.Comment}}
         {{ $item.Comment }}
     {{- end}}
-    {{ $enum.Name }}{{ $item.Name }} {{ $enum.Name }} = {{ if eq $item.ResultType "int" }}{{ .ResultIntValue }}
+    {{ $item.GoName }} {{ $enum.Name }} = {{ if eq $item.ResultType "int" }}{{ .ResultIntValue }}
     {{- else if eq $item.ResultType "string" }}{{ .ResultStringValue }}
     {{- else }}UNSUPPORTED
     {{- end }}
@@ -25,19 +25,19 @@ var _{{ $enum.Name }}Names = []string{
 
 var _{{ $enum.Name }}Values = []{{ $enum.Name }}{
 {{- range $ix, $item := $enum.Items }}
-    {{ $enum.Name }}{{ $item.Name }},
+    {{ $item.GoName }},
 {{- end }}
 }
 
 var _{{ $enum.Name }}Name = map[{{ $enum.Name }}]string{
 {{- range $ix, $item := $enum.Items }}
-    {{ $enum.Name }}{{ $item.Name }}: "{{ $item.Name }}",
+    {{ $item.GoName }}: "{{ $item.Name }}",
 {{- end }}
 }
 
 var _{{ $enum.Name }}NameToValue = map[string]{{ $enum.Name }}{
 {{- range $ix, $item := $enum.Items }}
-    "{{ $item.Name }}": {{ $enum.Name }}{{ $item.Name }},
+    "{{ $item.Name }}": {{ $item.GoName }},
 {{- end }}
 }
 

--- a/internal/visitor/visitor.go
+++ b/internal/visitor/visitor.go
@@ -362,7 +362,7 @@ func (v *Visitor) VisitEnumDeclaration(ctx *parser.EnumDeclarationContext) any {
 		Type:    v.VisitTypeInstantiation(ctx.TypeInstantiation().(*parser.TypeInstantiationContext)).(*ast.TypeReference),
 	}
 	for _, enumItem := range ctx.AllEnumItem() {
-		typ.Items = append(typ.Items, v.VisitEnumItem(enumItem.(*parser.EnumItemContext)).(*ast.EnumItem))
+		typ.AddItem(v.VisitEnumItem(enumItem.(*parser.EnumItemContext)).(*ast.EnumItem))
 	}
 	return typ
 }

--- a/test/BUILD.bazel
+++ b/test/BUILD.bazel
@@ -16,9 +16,14 @@ go_test(
 
 go_test(
     name = "test_test",
-    srcs = ["enum_test.go"],
+    srcs = [
+        "enum_test.go",
+        "struct_test.go",
+    ],
     deps = [
+        "//:go-zserio",
         "//testdata/reference_modules:go_core_types",
         "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/test/enum_test.go
+++ b/test/enum_test.go
@@ -36,7 +36,7 @@ func TestStringer(t *testing.T) {
 		want  string
 	}{
 		"known-value": {
-			input: types.SomeEnumATTR_A,
+			input: types.SomeEnumAttrA,
 			want:  "ATTR_A",
 		},
 		"unknown-value": {

--- a/test/reference/reference_test.go
+++ b/test/reference/reference_test.go
@@ -62,11 +62,11 @@ func want() testobject.TestObject {
 			Parameter:   d.Parameter1,
 			Value:       72,
 			OtherValue:  121,
-			EnumValue:   types.ColorBLUE,
+			EnumValue:   types.ColorBlue,
 			Description: "test data",
 		},
 	}
-	d.Color1 = types.ColorRED
+	d.Color1 = types.ColorRed
 
 	d.Parameter2 = 12
 	for i := 0; i < 22; i++ {
@@ -99,7 +99,7 @@ func want() testobject.TestObject {
 
 	// The next test is for the correct lookup of choice selector types. The
 	// choice below is using an enum, whose values also exist in a different enum
-	d.ChoiceSelector = types.SomeEnumHAS_A
+	d.ChoiceSelector = types.SomeEnumHasA
 	d.BasicChoice = types.BasicChoice{
 		Type: d.ChoiceSelector,
 		HasA: 5,

--- a/test/struct_test.go
+++ b/test/struct_test.go
@@ -1,0 +1,21 @@
+package reference
+
+import (
+	"gen/github.com/woven-planet/go-zserio/testdata/reference_modules/core/types"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	zserio "github.com/woven-planet/go-zserio"
+)
+
+func TestOptionalField(t *testing.T) {
+	value := &types.ValueWrapper{Parameter: 0, Value: 15, EnumValue: types.ColorRed}
+	dataWithoutOptional, err := zserio.Marshal(value)
+	require.NoError(t, err)
+
+	value.Parameter = 7
+	dataWithOptional, err := zserio.Marshal(value)
+	require.NoError(t, err)
+	require.Greater(t, len(dataWithOptional), len(dataWithoutOptional))
+}

--- a/testdata/BUILD.bazel
+++ b/testdata/BUILD.bazel
@@ -22,6 +22,7 @@ filegroup(
         "enum_expressions.zs",
         "field_alignment.zs",
         "struct_bitfield.zs",
+        "struct_optional_field.zs",
         "struct_simple.zs",
         "struct_template.zs",
     ]
@@ -37,6 +38,7 @@ build_test(
         ":enum_expressions",
         ":field_alignment",
         ":struct_bitfield",
+        ":struct_optional_field",
         ":struct_simple",
         ":struct_template",
     ],

--- a/testdata/struct_optional_field.zs
+++ b/testdata/struct_optional_field.zs
@@ -1,0 +1,12 @@
+package struct_optional_field
+
+enum uint8 State
+{
+    ERROR = 0,
+    SUCCESS = 1,
+};
+
+struct Result {
+    State status;
+    string message if status == State.ERROR;
+};


### PR DESCRIPTION
In Go use of UPPERCASE names is discouraged.