### PR TITLE
Better error message for invalid array length

### DIFF
--- a/internal/generator/templates/encode.go.tmpl
+++ b/internal/generator/templates/encode.go.tmpl
@@ -40,7 +40,7 @@
     {{- template "array_init.go.tmpl" dict "pkg" $scope "field_name" $field_name "field" $field "native" $native }}
     {{- if $field.Array.Length }}
         if len({{ $field_name }}) != int({{ goExpression $scope $field.Array.Length }}) {
-            return errors.New("array size does not match!")
+            return fmt.Errorf("{{ $field.Name }} array must have a size of %d", int({{ goExpression $scope $field.Array.Length }}))
         }
     {{- end }}
     {{- if $native.IsMarshaler }}

--- a/internal/generator/templates/packing_context_encode.go.tmpl
+++ b/internal/generator/templates/packing_context_encode.go.tmpl
@@ -42,7 +42,7 @@
     {{- template "array_init.go.tmpl" dict "pkg" $scope "field_name" $field_name "field" $field "native" $native }}
     {{- if $field.Array.Length }}
         if len({{ $field_name }}) != int({{ goExpression $scope $field.Array.Length }}) {
-            return errors.New("array size does not match!")
+            return fmt.Errorf("{{ $field.Name }} array must have a size of %d", int({{ goExpression $scope $field.Array.Length }}))
         }
     {{- end }}
 {{- end }}


### PR DESCRIPTION
Instead of a very generic `array size does not match!` we now generate a more clear `<field> array must have a size of ##` error.