### PR TITLE
Correct encoding of boolean arrays

### DIFF
--- a/internal/ast/scope.go
+++ b/internal/ast/scope.go
@@ -63,7 +63,7 @@ var zserioTypeToArrayTraits = map[string]string{
 	"varuint32": "ztype.VarUInt32ArrayTraits",
 	"varuint64": "ztype.VarUInt64ArrayTraits",
 	// bool types
-	"bool": "ztype.BitFieldArrayTraits",
+	"bool": "ztype.BooleanArrayTraits",
 	// string types
 	"string": "ztype.StringArrayTraits",
 	// float types

--- a/test/reference/boolean_array/BUILD.bazel
+++ b/test/reference/boolean_array/BUILD.bazel
@@ -1,0 +1,46 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_test")
+load("//:rules.bzl", "go_zserio_library")
+load("//test/rules:rules.bzl", "py_zserio_library", "zs_payload")
+
+go_zserio_library(
+    name = "go_lib",
+    srcs = [":schema.zs"],
+    pkg = "boolean_array.schema",
+    rootpackage = "gen/github.com/woven-planet/go-zserio/testdata",
+)
+
+py_zserio_library(
+    name = "py_lib",
+    outs = [
+        "boolean_array/schema/__init__.py",
+        "boolean_array/schema/api.py",
+        "boolean_array/schema/boolean_array.py",
+    ],
+    prefix = "testdata",
+    proto = ":schema.zs",
+)
+
+zs_payload(
+    name = "testdata",
+    srcs = ["data.py"],
+    out = "testdata.bin",
+    deps = [":py_lib"],
+)
+
+go_test(
+    name = "boolean_array",
+    srcs = ["test.go"],
+    data = [
+        ":testdata",
+    ],
+    env = {
+        "TESTDATA_BIN": "$(rootpath :testdata)",
+    },
+    deps = [
+        ":go_lib",
+        "//:go-zserio",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+        "@io_bazel_rules_go//go/tools/bazel:go_default_library",
+    ],
+)

--- a/test/reference/boolean_array/data.py
+++ b/test/reference/boolean_array/data.py
@@ -1,0 +1,6 @@
+from testdata.boolean_array.schema.api import BooleanArray
+
+
+def new():
+    array = BooleanArray([True, False, True, True, False])
+    return array

--- a/test/reference/boolean_array/schema.zs
+++ b/test/reference/boolean_array/schema.zs
@@ -1,0 +1,7 @@
+package boolean_array.schema;
+
+
+struct BooleanArray
+{
+    bool list[5];
+};

--- a/test/reference/boolean_array/test.go
+++ b/test/reference/boolean_array/test.go
@@ -1,0 +1,50 @@
+package reference
+
+import (
+	"gen/github.com/woven-planet/go-zserio/testdata/boolean_array/schema"
+	"os"
+	"testing"
+
+	"github.com/bazelbuild/rules_go/go/tools/bazel"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	zserio "github.com/woven-planet/go-zserio"
+)
+
+func testWorkspace(t require.TestingT, filePath string) string {
+	actualPath, err := bazel.Runfile(filePath)
+	require.NoError(t, err)
+	return actualPath
+}
+
+// ReferenceFilePath is the path to the input data.
+var ReferenceFilePath string = os.Getenv("TESTDATA_BIN")
+
+func TestRoundTrip(t *testing.T) {
+	// Given
+	want, err := os.ReadFile(testWorkspace(t, ReferenceFilePath))
+	require.NoError(t, err)
+
+	// When
+	var object schema.BooleanArray
+	require.NoError(t, zserio.Unmarshal(want, &object), "unmarshal")
+	got, err := zserio.Marshal(&object)
+	require.NoError(t, err, "marshal")
+
+	// Then
+	assert.Equal(t, want, got)
+}
+
+func TestEqual(t *testing.T) {
+	// Given
+	bytes, err := os.ReadFile(testWorkspace(t, ReferenceFilePath))
+	require.NoError(t, err)
+
+	// When
+	var got schema.BooleanArray
+	require.NoError(t, zserio.Unmarshal(bytes, &got))
+
+	// Then
+	want := schema.BooleanArray{List: []bool{true, false, true, true, false}}
+	assert.Equal(t, want, got)
+}

--- a/ztype/array_decode_test.go
+++ b/ztype/array_decode_test.go
@@ -258,6 +258,36 @@ func TestFloat64ArrayDecoding(t *testing.T) {
 		})
 	}
 }
+
+func TestBooleanArrayDecoding(t *testing.T) {
+	tests := map[string]struct {
+		input     []byte
+		arraySize int
+		isAuto    bool
+		want      []bool
+	}{
+		"auto-boolean-array": {
+			input:  []byte{0x05, 0xB0},
+			isAuto: true,
+			want:   []bool{true, false, true, true, false},
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			r := zstream.NewReader(bytes.NewBuffer(test.input))
+			array, err := ztype.ArrayFromReader[bool](
+				r, &ztype.BooleanArrayTraits{},
+				test.arraySize, false, test.isAuto)
+			if err != nil {
+				t.Fatalf("error reading array: %v", err)
+			}
+			if diff := cmp.Diff(test.want, array.RawArray); diff != "" {
+				t.Errorf("incorrect encoding: %s", diff)
+			}
+		})
+	}
+}
+
 func TestStringArrayDecoding(t *testing.T) {
 	tests := map[string]struct {
 		input     []byte

--- a/ztype/array_encode_test.go
+++ b/ztype/array_encode_test.go
@@ -248,6 +248,33 @@ func TestFloat64ArrayEncoding(t *testing.T) {
 		})
 	}
 }
+
+func TestBooleanArrayEncoding(t *testing.T) {
+	tests := map[string]struct {
+		arrayData []bool
+		arraySize int
+		isAuto    bool
+		want      []byte
+	}{
+		"auto-boolean-array": {
+			arrayData: []bool{true, false, true, true, false},
+			isAuto:    true,
+			want:      []byte{0x05, 0xB0},
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			arrayInstance := ztype.Array[bool, *ztype.BooleanArrayTraits]{
+				ArrayTraits: &ztype.BooleanArrayTraits{},
+				RawArray:    test.arrayData,
+				IsAuto:      test.isAuto,
+			}
+
+			assertEqualAfterMarshaling(t, test.want, &arrayInstance)
+		})
+	}
+}
+
 func TestStringArrayEncoding(t *testing.T) {
 	tests := map[string]struct {
 		arrayData []string

--- a/ztype/array_traits.go
+++ b/ztype/array_traits.go
@@ -651,6 +651,56 @@ func (trait BitFieldArrayTraits[T]) FromUint64(value uint64) T {
 	return T(value)
 }
 
+type BooleanArrayTraits struct{}
+
+func (trait BooleanArrayTraits) PackedTraits() IPackedArrayTraits[bool] {
+	return &PackedArrayTraits[bool, BooleanArrayTraits]{
+		ArrayTraits: trait,
+	}
+}
+
+func (trait BooleanArrayTraits) BitSizeOfIsConstant() bool {
+	return true
+}
+
+func (trait BooleanArrayTraits) NeedsBitsizeOfPosition() bool {
+	return false
+}
+
+func (trait BooleanArrayTraits) NeedsReadIndex() bool {
+	return false
+}
+
+func (trait BooleanArrayTraits) BitSizeOf(element bool, endBitPosition int) int {
+	// The bit size is always constant (1). The bit size of a boolean does not
+	// depend on the position in the array, endBitPosition is therefore not used.
+	return 1
+}
+
+func (trait BooleanArrayTraits) InitializeOffsets(bitPosition int, value bool) int {
+	return bitPosition + trait.BitSizeOf(value, 0) // endBitPosition is ignored
+}
+
+func (trait BooleanArrayTraits) Read(reader zserio.Reader, endBitPosition int) (bool, error) {
+	return ReadBool(reader)
+}
+
+func (trait BooleanArrayTraits) Write(writer zserio.Writer, value bool) error {
+	return WriteBool(writer, value)
+}
+
+func (trait BooleanArrayTraits) AsUint64(value bool) uint64 {
+	if value {
+		return 1
+	}
+
+	return 0
+}
+
+func (trait BooleanArrayTraits) FromUint64(value uint64) bool {
+	return value != 0
+}
+
 type StringArrayTraits struct{}
 
 func (trait StringArrayTraits) PackedTraits() IPackedArrayTraits[string] {


### PR DESCRIPTION
To support (de)serialization of array of boolean, e.g.

```
struct ArrayExample
{
    bool  list[4];
};
```
