### PR TITLE
Fix wrong last byte in Extern types if size is not byte aligned

### DIFF
--- a/ztype/extern_decode.go
+++ b/ztype/extern_decode.go
@@ -30,6 +30,8 @@ func ReadExtern(r zserio.Reader) (*ExternType, error) {
 		if err != nil {
 			return nil, err
 		}
+		numOfBitShift := 8 - remainingBits
+		lastByte = lastByte << numOfBitShift
 		e.Buffer = append(e.Buffer, byte(lastByte))
 	}
 	return e, nil


### PR DESCRIPTION
- The content of an extern zserio data type would be wrong, if the
  size of the extern block would not be byte aligned. The problem
  was that the last bits were read correctly, but not padded with
  zeros to make a full byte.
- The issue has been fixed by padding the read bits with zeros,
  to form a complete byte.