### PR TITLE
Support Index Expression

### DIFF
--- a/internal/ast/expression.go
+++ b/internal/ast/expression.go
@@ -146,6 +146,13 @@ func evaluateSymbolType(symbol any, scope *Package) (ExpressionType, error) {
 	}
 }
 
+// evaluateIndexExpression evaluates an index expression, such as [@index].
+func (expr *Expression) evaluateIndexExpression() error {
+	expr.ResultType = ExpressionTypeInteger
+	expr.FullyResolved = false
+	return nil
+}
+
 // evaluateIdentifier evaluates an identifier expression.
 func (expr *Expression) evaluateIdentifier(scope *Package) error {
 	symbol, err := scope.GetSymbol(expr.Text)
@@ -733,6 +740,8 @@ func (expr *Expression) Evaluate(scope *Package) error {
 		if "true" == strings.TrimSpace(strings.ToLower(expr.Text)) {
 			expr.ResultBoolValue = true
 		}
+	case parser.ZserioParserINDEX:
+		err = expr.evaluateIndexExpression()
 	case parser.ZserioParserID:
 		err = expr.evaluateIdentifier(scope)
 	case parser.UnevaluatableExpressionType:

--- a/internal/generator/expression.go
+++ b/internal/generator/expression.go
@@ -245,6 +245,9 @@ func ExpressionToGoString(scope ast.Scope, expression *ast.Expression) string {
 		return twoOperatorEqualTypesToGoString(scope, expression)
 	case parser.ZserioParserNE:
 		return twoOperatorEqualTypesToGoString(scope, expression)
+	case parser.ZserioParserINDEX:
+		// hard-code the name of the index variable used in the template
+		return "index"
 	case parser.ZserioParserID:
 		return IdentifierToGoString(scope, expression)
 	case parser.ZserioParserQUESTIONMARK:


### PR DESCRIPTION
- zserio has this funny "@index" expression, which indicates to use the same array index as the current array position.
- This expression type is now supported.