### PR TITLE
Restore the Scope after evaluating a Function Call

### DIFF
--- a/internal/ast/expression.go
+++ b/internal/ast/expression.go
@@ -259,6 +259,7 @@ func (expr *Expression) evaluateFunctionCallExpression(scope *Package) error {
 	if err != nil {
 		return err
 	}
+	previousScope := functionEvaluationScope.LocalSymbols.CurrentCompoundScope
 	functionEvaluationScope.LocalSymbols.CurrentCompoundScope = &typeRef.Type.Name
 	err = function.Result.Evaluate(functionEvaluationScope)
 	if err != nil {
@@ -268,6 +269,9 @@ func (expr *Expression) evaluateFunctionCallExpression(scope *Package) error {
 	// copy the result symbol, in case the type of the symbol needs to be
 	// evaluated.
 	expr.ResultSymbol = expr.Operand1.ResultSymbol
+
+	// Restore the previous scope
+	functionEvaluationScope.LocalSymbols.CurrentCompoundScope = previousScope
 	return nil
 }
 


### PR DESCRIPTION
- When a function call is evaluated, the scope is changed to the scope of the function to be able to evaluate the body of the function. However, when the call returns, the scope should be restored to the context of the caller, so that subsequent fields can be successfully evaluated.