### PR TITLE
Several Improvements to the Expression Generation

### DIFF
--- a/internal/generator/expression.go
+++ b/internal/generator/expression.go
@@ -30,9 +30,20 @@ func IdentifierToGoString(scope ast.Scope, expression *ast.Expression) string {
 		return name
 	case *ast.BitmaskType:
 		return name
+	case *ast.Function:
+		return "v." + n.Name
 	default:
 		return "UNSUPPORTED_TYPE"
 	}
+}
+
+// bracketedExpressionToGoString prints an array access expression,
+// such as array[index].
+func bracketedExpressionToGoString(scope ast.Scope, expression *ast.Expression) string {
+	return fmt.Sprintf("%s[%s]",
+		ExpressionToGoString(scope, expression.Operand1),
+		ExpressionToGoString(scope, expression.Operand2),
+	)
 }
 
 func parenthesizedExpressionToGoString(scope ast.Scope, expression *ast.Expression) string {
@@ -173,10 +184,23 @@ func twoOperatorToGoString(scope ast.Scope, expression *ast.Expression) string {
 }
 
 func ternaryExpressionToGoString(scope ast.Scope, expression *ast.Expression) string {
+	op1 := ExpressionToGoString(scope, expression.Operand1)
+	op2 := ExpressionToGoString(scope, expression.Operand2)
+	op3 := ExpressionToGoString(scope, expression.Operand3)
+	if expression.ResultType == ast.ExpressionTypeInteger {
+		// in case the expression is a subtype of int (such as uint16), cast to
+		// integer to avoid type cast errors
+		typeCast := "int"
+		op3 = fmt.Sprintf("%s(%s)", typeCast, op3)
+		op2 = fmt.Sprintf("%s(%s)", typeCast, op2)
+	}
+	// Ternary expressions are not supported by Go. As a workaround,
+	// generate the ternary expression as an if/else
 	return fmt.Sprintf("%s\nif %s {\nretVal = %s\n}\n",
-		ExpressionToGoString(scope, expression.Operand3),
-		ExpressionToGoString(scope, expression.Operand1),
-		ExpressionToGoString(scope, expression.Operand2))
+		op3,
+		op1,
+		op2,
+	)
 }
 
 func lenOperatorToGoString(scope ast.Scope, expression *ast.Expression) string {
@@ -197,6 +221,8 @@ func ExpressionToGoString(scope ast.Scope, expression *ast.Expression) string {
 		}
 	}
 	switch expression.Type {
+	case parser.ZserioParserLBRACKET:
+		return bracketedExpressionToGoString(scope, expression)
 	case parser.ZserioParserLPAREN:
 		return parenthesizedExpressionToGoString(scope, expression)
 	case parser.ZserioParserRPAREN:


### PR DESCRIPTION
- Support bracket [] expressions, i.e. accessing an array element.
- Improve the ternary operator generation by adding type casts for integers. Since Go is pretty strict with the types, not all integer types will be assignable to each other, for example int and int16. Therefore, all integer types are casted to int first, and only casted to the final type when the function returns.
- Support function call expressions, if the identifier is a function. This would be the case if a function of a struct calls another function of the same struct.