### PR TITLE
Fix negative Bitmask Array Values

### DIFF
--- a/internal/ast/scope.go
+++ b/internal/ast/scope.go
@@ -41,15 +41,15 @@ var zserioTypeToGoType = map[string]string{
 
 var zserioTypeToArrayTraits = map[string]string{
 	// integer types
-	"int8":   "ztype.BitFieldArrayTraits",
-	"int16":  "ztype.BitFieldArrayTraits",
-	"int32":  "ztype.BitFieldArrayTraits",
-	"int64":  "ztype.BitFieldArrayTraits",
+	"int8":   "ztype.SignedBitFieldArrayTraits",
+	"int16":  "ztype.SignedBitFieldArrayTraits",
+	"int32":  "ztype.SignedBitFieldArrayTraits",
+	"int64":  "ztype.SignedBitFieldArrayTraits",
 	"uint8":  "ztype.BitFieldArrayTraits",
 	"uint16": "ztype.BitFieldArrayTraits",
 	"uint32": "ztype.BitFieldArrayTraits",
 	"uint64": "ztype.BitFieldArrayTraits",
-	"int":    "ztype.BitFieldArrayTraits",
+	"int":    "ztype.SignedBitFieldArrayTraits",
 	"uint":   "ztype.BitFieldArrayTraits",
 	"bit":    "ztype.BitFieldArrayTraits",
 	// varint types

--- a/internal/generator/templates/array_traits_type.go.tmpl
+++ b/internal/generator/templates/array_traits_type.go.tmpl
@@ -3,4 +3,5 @@
 {{- $traits := goArrayTraits $scope $type }}
 {{- $traits }}
 {{- if eq $traits "ztype.BitFieldArrayTraits" }}[{{ goType $scope $type }}]{{- end -}}
+{{- if eq $traits "ztype.SignedBitFieldArrayTraits" }}[{{ goType $scope $type }}]{{- end -}}
 {{- if eq $traits "ztype.ObjectArrayTraits" }}[*{{ goType $scope $type }}]{{- end -}}

--- a/internal/generator/templates/instantiate_array_traits.go.tmpl
+++ b/internal/generator/templates/instantiate_array_traits.go.tmpl
@@ -2,7 +2,7 @@
 {{- $type := .type }}
 {{- $traits := goArrayTraits $scope $type }}
 {{- template "array_traits_type.go.tmpl" dict "pkg" $scope "type" $type }} {
-{{- if eq $traits "ztype.BitFieldArrayTraits" -}}
+{{- if or (eq $traits "ztype.BitFieldArrayTraits") (eq $traits "ztype.SignedBitFieldArrayTraits") -}}
     NumBits: uint8(
     {{- if gt $type.Bits 0 }}
         {{- $type.Bits }}

--- a/test/reference/packed_int16_array/BUILD.bazel
+++ b/test/reference/packed_int16_array/BUILD.bazel
@@ -1,0 +1,46 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_test")
+load("//:rules.bzl", "go_zserio_library")
+load("//test/rules:rules.bzl", "py_zserio_library", "zs_payload")
+
+go_zserio_library(
+    name = "go_lib",
+    srcs = [":schema.zs"],
+    pkg = "packed_int16_array.schema",
+    rootpackage = "gen/github.com/woven-planet/go-zserio/testdata",
+)
+
+py_zserio_library(
+    name = "py_lib",
+    outs = [
+        "packed_int16_array/schema/__init__.py",
+        "packed_int16_array/schema/api.py",
+        "packed_int16_array/schema/packed_int16_array.py",
+    ],
+    prefix = "testdata",
+    proto = ":schema.zs",
+)
+
+zs_payload(
+    name = "testdata",
+    srcs = ["data.py"],
+    out = "testdata.bin",
+    deps = [":py_lib"],
+)
+
+go_test(
+    name = "packed_int16_array",
+    srcs = ["test.go"],
+    data = [
+        ":testdata",
+    ],
+    env = {
+        "TESTDATA_BIN": "$(rootpath :testdata)",
+    },
+    deps = [
+        ":go_lib",
+        "//:go-zserio",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+        "@io_bazel_rules_go//go/tools/bazel:go_default_library",
+    ],
+)

--- a/test/reference/packed_int16_array/data.py
+++ b/test/reference/packed_int16_array/data.py
@@ -1,0 +1,6 @@
+from testdata.packed_int16_array.schema.api import PackedInt16Array
+
+
+def new():
+    array = PackedInt16Array([-15, -14, -13, -16, -11])
+    return array

--- a/test/reference/packed_int16_array/schema.zs
+++ b/test/reference/packed_int16_array/schema.zs
@@ -1,0 +1,7 @@
+package packed_int16_array.schema;
+
+
+struct PackedInt16Array
+{
+    packed int16 list[5];
+};

--- a/test/reference/packed_int16_array/test.go
+++ b/test/reference/packed_int16_array/test.go
@@ -1,0 +1,50 @@
+package reference
+
+import (
+	"gen/github.com/woven-planet/go-zserio/testdata/packed_int16_array/schema"
+	"os"
+	"testing"
+
+	"github.com/bazelbuild/rules_go/go/tools/bazel"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	zserio "github.com/woven-planet/go-zserio"
+)
+
+func testWorkspace(t require.TestingT, filePath string) string {
+	actualPath, err := bazel.Runfile(filePath)
+	require.NoError(t, err)
+	return actualPath
+}
+
+// ReferenceFilePath is the path to the input data.
+var ReferenceFilePath string = os.Getenv("TESTDATA_BIN")
+
+func TestRoundTrip(t *testing.T) {
+	// Given
+	want, err := os.ReadFile(testWorkspace(t, ReferenceFilePath))
+	require.NoError(t, err)
+
+	// When
+	var object schema.PackedInt16Array
+	require.NoError(t, zserio.Unmarshal(want, &object), "unmarshal")
+	got, err := zserio.Marshal(&object)
+	require.NoError(t, err, "marshal")
+
+	// Then
+	assert.Equal(t, want, got)
+}
+
+func TestEqual(t *testing.T) {
+	// Given
+	bytes, err := os.ReadFile(testWorkspace(t, ReferenceFilePath))
+	require.NoError(t, err)
+
+	// When
+	var got schema.PackedInt16Array
+	require.NoError(t, zserio.Unmarshal(bytes, &got))
+
+	// Then
+	want := schema.PackedInt16Array{List: []int16{-15, -14, -13, -16, -11}}
+	assert.Equal(t, want, got)
+}

--- a/test/reference/packed_position2d_array/BUILD.bazel
+++ b/test/reference/packed_position2d_array/BUILD.bazel
@@ -1,0 +1,47 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_test")
+load("//:rules.bzl", "go_zserio_library")
+load("//test/rules:rules.bzl", "py_zserio_library", "zs_payload")
+
+go_zserio_library(
+    name = "go_lib",
+    srcs = [":schema.zs"],
+    pkg = "packed_position2d_array.schema",
+    rootpackage = "gen/github.com/woven-planet/go-zserio/testdata",
+)
+
+py_zserio_library(
+    name = "py_lib",
+    outs = [
+        "packed_position2d_array/schema/__init__.py",
+        "packed_position2d_array/schema/api.py",
+        "packed_position2d_array/schema/packed_position2d_array.py",
+        "packed_position2d_array/schema/position2d.py",
+    ],
+    prefix = "testdata",
+    proto = ":schema.zs",
+)
+
+zs_payload(
+    name = "testdata",
+    srcs = ["data.py"],
+    out = "testdata.bin",
+    deps = [":py_lib"],
+)
+
+go_test(
+    name = "packed_position2d_array",
+    srcs = ["test.go"],
+    data = [
+        ":testdata",
+    ],
+    env = {
+        "TESTDATA_BIN": "$(rootpath :testdata)",
+    },
+    deps = [
+        ":go_lib",
+        "//:go-zserio",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+        "@io_bazel_rules_go//go/tools/bazel:go_default_library",
+    ],
+)

--- a/test/reference/packed_position2d_array/data.py
+++ b/test/reference/packed_position2d_array/data.py
@@ -1,0 +1,14 @@
+from testdata.packed_position2d_array.schema.api import PackedPosition2DArray, Position2D
+
+
+def new():
+    positions: list[Position2D] = [
+        Position2D(shift_=0, x_=-3112, y_=-12),
+        Position2D(shift_=0, x_=-3113, y_=-11),
+        Position2D(shift_=0, x_=-3114, y_=-12),
+        Position2D(shift_=0, x_=-3115, y_=-11),
+        Position2D(shift_=0, x_=-3116, y_=-12),
+        Position2D(shift_=0, x_=-3117, y_=-11),
+    ]
+    array = PackedPosition2DArray(positions)
+    return array

--- a/test/reference/packed_position2d_array/schema.zs
+++ b/test/reference/packed_position2d_array/schema.zs
@@ -1,0 +1,12 @@
+package packed_position2d_array.schema;
+
+struct Position2D(int shift)
+{
+  int<(31-shift) + 1> x;
+  int<(31-shift) + 1> y;
+};
+
+struct PackedPosition2DArray
+{
+    packed Position2D(0) positions[6];
+};

--- a/test/reference/packed_position2d_array/test.go
+++ b/test/reference/packed_position2d_array/test.go
@@ -1,0 +1,57 @@
+package reference
+
+import (
+	"gen/github.com/woven-planet/go-zserio/testdata/packed_position2d_array/schema"
+	"os"
+	"testing"
+
+	"github.com/bazelbuild/rules_go/go/tools/bazel"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	zserio "github.com/woven-planet/go-zserio"
+)
+
+func testWorkspace(t require.TestingT, filePath string) string {
+	actualPath, err := bazel.Runfile(filePath)
+	require.NoError(t, err)
+	return actualPath
+}
+
+// ReferenceFilePath is the path to the input data.
+var ReferenceFilePath string = os.Getenv("TESTDATA_BIN")
+
+func TestRoundTrip(t *testing.T) {
+	// Given
+	want, err := os.ReadFile(testWorkspace(t, ReferenceFilePath))
+	require.NoError(t, err)
+
+	// When
+	var object schema.PackedPosition2DArray
+	require.NoError(t, zserio.Unmarshal(want, &object), "unmarshal")
+	got, err := zserio.Marshal(&object)
+	require.NoError(t, err, "marshal")
+
+	// Then
+	assert.Equal(t, want, got)
+}
+
+func TestEqual(t *testing.T) {
+	// Given
+	bytes, err := os.ReadFile(testWorkspace(t, ReferenceFilePath))
+	require.NoError(t, err)
+
+	// When
+	var got schema.PackedPosition2DArray
+	require.NoError(t, zserio.Unmarshal(bytes, &got))
+
+	// Then
+	want := schema.PackedPosition2DArray{Positions: []schema.Position2D{
+		{Shift: 0, X: -3112, Y: -12},
+		{Shift: 0, X: -3113, Y: -11},
+		{Shift: 0, X: -3114, Y: -12},
+		{Shift: 0, X: -3115, Y: -11},
+		{Shift: 0, X: -3116, Y: -12},
+		{Shift: 0, X: -3117, Y: -11},
+	}}
+	assert.Equal(t, want, got)
+}


### PR DESCRIPTION
- This PR fixes the issue reported in https://github.com/woven-planet/go-zserio/issues/103.
- The root cause is that bitmask array values, such as int<5>, were not checked for their sign type. Internally, go-zserio is using int64 to store these values.
- If, for example, a negative value of an `int<15>` would be stored, it would look like: `0x7FF3`. Note that the highest bit, which is used to identify the sign, is located at bit position 15. However, since we are using `int64`, only the 64th bit is processed as a sign.
- The conversion step which checks if the `int15` is negative, and subsequently also makes the int64 negative, was missing.
- This PR fixes this by introducing a new `SignedBitfieldArrayTraits`, which considers the sign of the bitfield.
- This PR also adds testcases for the above scenario.