### PR TITLE
Limit maximum file path name for Windows compatibility

### DIFF
--- a/internal/cli/generate.go
+++ b/internal/cli/generate.go
@@ -16,6 +16,8 @@ var (
 	topLevelPackage string
 	noFormat        bool
 	emitSQLSupport  bool
+	limitPathLength bool
+	maxPathLength   int
 	outputPackage   string
 )
 
@@ -35,6 +37,9 @@ var generateCmd = &cobra.Command{
 		}
 		if emitSQLSupport {
 			options = append(options, generator.EmitSQLSupport)
+		}
+		if limitPathLength {
+			options = append(options, generator.PathLengthLimiter{MaxPathLength: maxPathLength}.LimitPathLength)
 		}
 
 		if err = generator.Generate(m,
@@ -63,6 +68,9 @@ func init() {
 	generateCmd.Flags().MarkHidden("noformat")
 
 	generateCmd.Flags().BoolVar(&emitSQLSupport, "sql", false, "Emit code for SQL support")
+
+	generateCmd.Flags().BoolVar(&limitPathLength, "limitlength", false, "Limit path length to the number of character passed to maxlength")
+	generateCmd.Flags().IntVar(&maxPathLength, "maxlength", generator.DefaultMaxPathLength, "Limit path length to the given number of characters")
 
 	rootCmd.AddCommand(generateCmd)
 }

--- a/internal/cli/generate.go
+++ b/internal/cli/generate.go
@@ -16,7 +16,6 @@ var (
 	topLevelPackage string
 	noFormat        bool
 	emitSQLSupport  bool
-	limitPathLength bool
 	maxPathLength   int
 	outputPackage   string
 )
@@ -38,7 +37,7 @@ var generateCmd = &cobra.Command{
 		if emitSQLSupport {
 			options = append(options, generator.EmitSQLSupport)
 		}
-		if limitPathLength {
+		if maxPathLength > 0 {
 			options = append(options, generator.PathLengthLimiter{MaxPathLength: maxPathLength}.LimitPathLength)
 		}
 
@@ -69,8 +68,7 @@ func init() {
 
 	generateCmd.Flags().BoolVar(&emitSQLSupport, "sql", false, "Emit code for SQL support")
 
-	generateCmd.Flags().BoolVar(&limitPathLength, "limitlength", false, "Limit path length to the number of character passed to maxlength")
-	generateCmd.Flags().IntVar(&maxPathLength, "maxlength", generator.DefaultMaxPathLength, "Limit path length to the given number of characters")
+	generateCmd.Flags().IntVar(&maxPathLength, "max-path-length", generator.DefaultMaxPathLength, "Maximum length of generated file paths. Set to 0 for no limit.")
 
 	rootCmd.AddCommand(generateCmd)
 }

--- a/internal/generator/gen_test.go
+++ b/internal/generator/gen_test.go
@@ -52,7 +52,7 @@ func TestStableOutputOrder(t *testing.T) {
 				for i := range second {
 					second[i].data = nil
 				}
-				assert.Equal(t, "pkg.go", first[0].name)
+				assert.Equal(t, "pkg", first[0].name)
 				assert.Equal(t, first, second)
 			})
 		}

--- a/internal/generator/gen_test.go
+++ b/internal/generator/gen_test.go
@@ -4,6 +4,7 @@ import (
 	"io"
 	"log"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -56,4 +57,28 @@ func TestStableOutputOrder(t *testing.T) {
 			})
 		}
 	}
+}
+
+func TestAssembleUniqueFilePath(t *testing.T) {
+	longRootDirectory := "/Users/my_user/my_projects/my_project_working_with_zserio/my_project_resources/my_zserio_schema_data"
+	longFileName := "my_very_sophisticated_zserio_template_based_data_type"
+	otherLongFileName := "my_other_very_sophisticated_zserio_template_based_data_type"
+
+	// Do not change current behaviour if limit is disabled
+	assert.Equal(t, path.Join(longRootDirectory, longFileName)+FileSuffix, assembleUniqueFilePath(longRootDirectory, longFileName, false, DefaultMaxPathLength))
+
+	// Do not change file path if length is below maximum
+	assert.Equal(t, path.Join(longRootDirectory, otherLongFileName)+FileSuffix, assembleUniqueFilePath(longRootDirectory, otherLongFileName, true, DefaultMaxPathLength))
+
+	// Shorten file name to stay below maximum
+	assert.Equal(t, path.Join(longRootDirectory, "my_very_sophisticated")+FileSuffix, assembleUniqueFilePath(longRootDirectory, longFileName, true, 130))
+
+	// Append indexed suffix if same file appears again
+	assert.Equal(t, path.Join(longRootDirectory, "my_very_sophisticated")+"_1"+FileSuffix, assembleUniqueFilePath(longRootDirectory, longFileName, true, 130))
+	assert.Equal(t, path.Join(longRootDirectory, "my_very_sophisticated")+"_2"+FileSuffix, assembleUniqueFilePath(longRootDirectory, longFileName, true, 130))
+
+	assert.Equal(t, path.Join(longRootDirectory, "my_other_very")+FileSuffix, assembleUniqueFilePath(longRootDirectory, otherLongFileName, true, 130))
+	assert.Equal(t, path.Join(longRootDirectory, "my_other_very")+"_1"+FileSuffix, assembleUniqueFilePath(longRootDirectory, otherLongFileName, true, 130))
+	assert.Equal(t, path.Join(longRootDirectory, "my_other_very")+"_2"+FileSuffix, assembleUniqueFilePath(longRootDirectory, otherLongFileName, true, 130))
+	assert.Equal(t, path.Join(longRootDirectory, "my_other_very")+"_3"+FileSuffix, assembleUniqueFilePath(longRootDirectory, otherLongFileName, true, 130))
 }

--- a/internal/model/transform.go
+++ b/internal/model/transform.go
@@ -539,13 +539,7 @@ func (m *Model) instantiateChoice(
 
 func generateInstantiatedName(tr *ast.TypeReference, templateArguments []*ast.TypeReference) string {
 	name := []string{strings.Title(tr.Name)}
-	nameLength := len(tr.Name)
 	for _, ta := range templateArguments {
-		nameLength += len(ta.Name)
-		// Long names make code hard to read and may cause problems on certain file systems
-		if nameLength > 60 {
-			break
-		}
 		name = append(name, strings.Title(ta.Name))
 	}
 	return strings.Join(name, "")

--- a/internal/model/transform.go
+++ b/internal/model/transform.go
@@ -539,7 +539,13 @@ func (m *Model) instantiateChoice(
 
 func generateInstantiatedName(tr *ast.TypeReference, templateArguments []*ast.TypeReference) string {
 	name := []string{strings.Title(tr.Name)}
+	nameLength := len(tr.Name)
 	for _, ta := range templateArguments {
+		nameLength += len(ta.Name)
+		// Long names make code hard to read and may cause problems on certain file systems
+		if nameLength > 60 {
+			break
+		}
 		name = append(name, strings.Title(ta.Name))
 	}
 	return strings.Join(name, "")


### PR DESCRIPTION
I would like to propose a solution for generating source files on or for use on Windows where we face a hard limit of 260 characters for the entire file path. The problem most commonly arises from complex template types for which all template type names are appended to the create a unique instantiated name. (fixes #95)

Our first attempt was to shorten the the instantiated name itself which could likely lead to conflicts with similar-looking template types. Instead we would like to propose limiting the length of the final \*.go file name, which in Go are not relevant for imports and therefore don't affect code generation. To ensure uniqueness we propose adding indexed suffixes, i.e. _\*_idx.go_ to the file name as needed. We've tested the approach for our own zserio schemas, which might differ from yours.

I'm curious to hear your thoughts and concerns about this change.

Philipp Voigt (<philipp.voigt@mercedes-benz.com>) on behalf of Mercedes-Benz Tech Innovation GmbH.
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)