### PR TITLE
Do not pre-compute arithmetic expressions, if the expression contains variables

### DIFF
--- a/internal/ast/expression.go
+++ b/internal/ast/expression.go
@@ -443,17 +443,27 @@ func (expr *Expression) evaluateArithmeticExpression() error {
 	// currently, only integer and string arithmetics are supported
 	if expr.Operand1.ResultType == ExpressionTypeInteger && expr.Operand2.ResultType == ExpressionTypeInteger {
 		expr.ResultType = ExpressionTypeInteger
+		op1 := expr.Operand1.ResultIntValue
+		op2 := expr.Operand2.ResultIntValue
+		if !expr.Operand1.FullyResolved || !expr.Operand2.FullyResolved {
+			// If the expression operands are not a fully defined to a constant,
+			// we fill in some dummy values for the sake of checking the correct
+			// operator.
+			op1 = 1
+			op2 = 1
+			expr.FullyResolved = false
+		}
 		switch expr.Type {
 		case parser.ZserioParserPLUS:
-			expr.ResultIntValue = expr.Operand1.ResultIntValue + expr.Operand2.ResultIntValue
+			expr.ResultIntValue = op1 + op2
 		case parser.ZserioParserMINUS:
-			expr.ResultIntValue = expr.Operand1.ResultIntValue - expr.Operand2.ResultIntValue
+			expr.ResultIntValue = op1 - op2
 		case parser.ZserioParserMULTIPLY:
-			expr.ResultIntValue = expr.Operand1.ResultIntValue * expr.Operand2.ResultIntValue
+			expr.ResultIntValue = op1 * op2
 		case parser.ZserioParserDIVIDE:
-			expr.ResultIntValue = expr.Operand1.ResultIntValue / expr.Operand2.ResultIntValue
+			expr.ResultIntValue = op1 / op2
 		case parser.ZserioParserMODULO:
-			expr.ResultIntValue = expr.Operand1.ResultIntValue % expr.Operand2.ResultIntValue
+			expr.ResultIntValue = op1 % op2
 		default:
 			return errors.New("unexpected operation in integer arithmetic expression")
 		}
@@ -462,6 +472,7 @@ func (expr *Expression) evaluateArithmeticExpression() error {
 		(expr.Operand1.ResultType == ExpressionTypeFloat && expr.Operand2.ResultType == ExpressionTypeInteger) {
 		// zserio supports mixing of integer and float operands. If these are mixed, the result
 		// type will always be a float type.
+		expr.ResultType = ExpressionTypeFloat
 		op1 := expr.Operand1.ResultFloatValue
 		op2 := expr.Operand2.ResultFloatValue
 		if expr.Operand1.ResultType == ExpressionTypeInteger {
@@ -470,8 +481,11 @@ func (expr *Expression) evaluateArithmeticExpression() error {
 		if expr.Operand2.ResultType == ExpressionTypeInteger {
 			op2 = float64(expr.Operand2.ResultIntValue)
 		}
-
-		expr.ResultType = ExpressionTypeFloat
+		if !expr.Operand1.FullyResolved || !expr.Operand2.FullyResolved {
+			op1 = 1.0
+			op2 = 1.0
+			expr.FullyResolved = false
+		}
 		switch expr.Type {
 		case parser.ZserioParserPLUS:
 			expr.ResultFloatValue = op1 + op2

--- a/internal/ast/expression_test.go
+++ b/internal/ast/expression_test.go
@@ -160,6 +160,22 @@ func TestFloatArithmeticExpressions(t *testing.T) {
 			operand:       parser.ZserioParserDIVIDE,
 			expectedValue: 3.0,
 		},
+		"do-not-divide-by-zero": {
+			testOperand1: &ast.Expression{
+				Type: parser.ZserioLexerDOUBLE_LITERAL,
+				Text: "9.9",
+			},
+			testOperand2: &ast.Expression{
+				Type:            parser.ZserioParserID,
+				FullyResolved:   false,
+				Text:            "some_identifier",
+				EvaluationState: ast.EvaluationStateComplete,
+				ResultType:      ast.ExpressionTypeInteger,
+				ResultIntValue:  0,
+			},
+			operand:       parser.ZserioParserDIVIDE,
+			expectedValue: 1.0,
+		},
 	}
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {


### PR DESCRIPTION
- If an expression is not fixed (depends on a variable), arithmetic
  operations within this expression cannot be evaluated. For example,
  a sum of a variable and 5 will still be a variable. It does not
  make sense to compute the sum at `zserio` generation time.
- This caused occasional division by zero errors
  (https://github.com/woven-planet/go-zserio/issues/109),
  because the code would assign a value of 0, if the expression is variable.
- The fix implemented in this PR is to check if the expression is fully
  defined (i.e. a constant value). If this is not the case, the arithmetic
  is done with dummy values (just to check that the right operator
  is used). These dummy values are set so that no division by 0 errors
  can occur.
- During code generation, the arithmetic expression is re-generated in
  Go code (no changes needed).

This PR is based on https://github.com/woven-planet/go-zserio/pull/111.