### PR TITLE
Fix Error when evaluating subtyped Enums

### DIFF
--- a/internal/ast/package.go
+++ b/internal/ast/package.go
@@ -129,6 +129,12 @@ func (p *Package) GoType(t *TypeReference) (string, error) {
 	return p.BaseScope.GoType(t)
 }
 
+// GoType looks up a name in the scope, and provides the Go type name for it.
+// If the type is not found ErrUnkownType is returned.
+func (p *Package) OriginalType(t *TypeReference) (*OriginalTypeReference, error) {
+	return p.GetOriginalType(t)
+}
+
 // GoArrayTraits returns the array traits object for non-basic zserio types,
 // such as enums, subtypes, or structures.
 func (p *Package) GoArrayTraits(t *TypeReference) (string, error) {

--- a/internal/ast/scope.go
+++ b/internal/ast/scope.go
@@ -105,6 +105,10 @@ type Scope interface {
 	// If the type is not found ErrUnkownType is returned.
 	GoType(t *TypeReference) (string, error)
 
+	// Returns the original zserio type, removing all indirections caused by
+	// subtyping.
+	OriginalType(T *TypeReference) (*OriginalTypeReference, error)
+
 	// GoArrayTraits looks up a name in the scope, and provides the array traits
 	// for it.
 	GoArrayTraits(t *TypeReference) (string, error)
@@ -136,6 +140,13 @@ func (s *BaseScope) GoType(t *TypeReference) (string, error) {
 		return s.Parent.GoType(t)
 	}
 	return "", fmt.Errorf("%w: %s", ErrUnknownType, t.Name)
+}
+
+func (s *BaseScope) OriginalType(t *TypeReference) (*OriginalTypeReference, error) {
+	if s.Parent != nil {
+		return s.Parent.OriginalType(t)
+	}
+	return nil, fmt.Errorf("%w: %s", ErrUnknownType, t.Name)
 }
 
 func (s *BaseScope) GoArrayTraits(t *TypeReference) (string, error) {
@@ -194,6 +205,10 @@ func (s *RootScope) GoType(t *TypeReference) (string, error) {
 		return goType, nil
 	}
 	return "", fmt.Errorf("%w: %s", ErrUnknownType, t.Name)
+}
+
+func (s *RootScope) OriginalType(t *TypeReference) (*OriginalTypeReference, error) {
+	return nil, fmt.Errorf("Root scope should never be called to resolve an original type %s", t.Name)
 }
 
 // GoArrayTraits returns the array traits for a zserio basic type (int, float, ...)

--- a/internal/generator/expression.go
+++ b/internal/generator/expression.go
@@ -83,7 +83,11 @@ func dotOperatorToGoString(scope ast.Scope, expression *ast.Expression) string {
 		}
 		// Generate the enum value using the original type name, as well as the
 		// enumeration value.
-		enumValue := originalType.Type.Name + strcase.ToCamel(strings.ToLower(expression.Operand2.Text))
+		originalEnumType, err := GoType(scope, originalType.Type)
+		if err != nil {
+			return "ENUM_GO_TYPE_DEDUCTION_FAILED"
+		}
+		enumValue := originalEnumType + strcase.ToCamel(strings.ToLower(expression.Operand2.Text))
 		if originalType.RequiresCast {
 			enumValue = fmt.Sprintf("%s(%s)", leftText, enumValue)
 		}

--- a/internal/generator/expression.go
+++ b/internal/generator/expression.go
@@ -83,7 +83,11 @@ func dotOperatorToGoString(scope ast.Scope, expression *ast.Expression) string {
 		}
 		// Generate the enum value using the original type name, as well as the
 		// enumeration value.
-		return originalType.Type.Name + strcase.ToCamel(strings.ToLower(expression.Operand2.Text))
+		enumValue := originalType.Type.Name + strcase.ToCamel(strings.ToLower(expression.Operand2.Text))
+		if originalType.RequiresCast {
+			enumValue = fmt.Sprintf("%s(%s)", leftText, enumValue)
+		}
+		return enumValue
 	} else if expression.Operand1.ResultType == ast.ExpressionTypeBitmask {
 		return leftText + rightText
 	}

--- a/internal/generator/funcs.go
+++ b/internal/generator/funcs.go
@@ -64,8 +64,8 @@ func GoExpression(scope ast.Scope, expression *ast.Expression) string {
 	return ExpressionToGoString(scope, expression)
 }
 
-func GoNativeType(pkg *ast.Package, typ *ast.TypeReference) (*ast.NativeZserioTypeReference, error) {
-	return pkg.GetZserioNativeType(typ)
+func GoNativeType(pkg *ast.Package, typ *ast.TypeReference) (*ast.OriginalTypeReference, error) {
+	return pkg.GetOriginalType(typ)
 }
 
 func Add(op1, op2 int) int {

--- a/test/reference/subtypes/BUILD.bazel
+++ b/test/reference/subtypes/BUILD.bazel
@@ -1,0 +1,46 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_test")
+load("//:rules.bzl", "go_zserio_library")
+load("//test/rules:rules.bzl", "py_zserio_library", "zs_payload")
+
+go_zserio_library(
+    name = "go_lib",
+    srcs = [":schema.zs"],
+    pkg = "subtypes.schema",
+    rootpackage = "gen/github.com/woven-planet/go-zserio/testdata",
+)
+
+py_zserio_library(
+    name = "py_lib",
+    outs = [
+        "subtypes/schema/__init__.py",
+        "subtypes/schema/api.py",
+        "subtypes/schema/subtypes.py",
+    ],
+    prefix = "testdata",
+    proto = ":schema.zs",
+)
+
+zs_payload(
+    name = "testdata",
+    srcs = ["data.py"],
+    out = "testdata.bin",
+    deps = [":py_lib"],
+)
+
+go_test(
+    name = "subtypes",
+    srcs = ["test.go"],
+    data = [
+        ":testdata",
+    ],
+    env = {
+        "TESTDATA_BIN": "$(rootpath :testdata)",
+    },
+    deps = [
+        ":go_lib",
+        "//:go-zserio",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+        "@io_bazel_rules_go//go/tools/bazel:go_default_library",
+    ],
+)

--- a/test/reference/subtypes/BUILD.bazel
+++ b/test/reference/subtypes/BUILD.bazel
@@ -14,7 +14,10 @@ py_zserio_library(
     outs = [
         "subtypes/schema/__init__.py",
         "subtypes/schema/api.py",
-        "subtypes/schema/subtypes.py",
+        "subtypes/schema/colour.py",
+        "subtypes/schema/dummy_struct.py",
+        "subtypes/schema/other_subtyped_colour.py",
+        "subtypes/schema/subtyped_colour.py",
     ],
     prefix = "testdata",
     proto = ":schema.zs",

--- a/test/reference/subtypes/data.py
+++ b/test/reference/subtypes/data.py
@@ -1,0 +1,9 @@
+from testdata.subtypes.schema.api import DummyStruct, Colour, SubtypedColour, OtherSubtypedColour
+
+
+def new() -> DummyStruct:
+    return DummyStruct(
+        colour1_=Colour.PURPLE,
+        colour2_=SubtypedColour.BLUE,
+        colour3_=OtherSubtypedColour.ORANGE,
+    )

--- a/test/reference/subtypes/schema.zs
+++ b/test/reference/subtypes/schema.zs
@@ -1,0 +1,37 @@
+package subtypes.schema;
+
+
+enum uint32 Colour
+{
+    RED,
+    PURPLE,
+    BLUE,
+    ORANGE,
+    CYAN,
+};
+
+// Apply two level of indirection for this test.
+subtype Colour SubtypedColour;
+subtype SubtypedColour OtherSubtypedColour;
+
+struct DummyStruct
+{
+    Colour colour1;
+    SubtypedColour colour2;
+    OtherSubtypedColour colour3;
+
+    function bool testColour1()
+    {
+        return (colour1 == Colour.RED);
+    }
+
+    function bool testColour2()
+    {
+        return (colour2 == SubtypedColour.RED);
+    }
+
+    function bool testColor3()
+    {
+        return (colour3 == OtherSubtypedColour.ORANGE);
+    }
+};

--- a/test/reference/subtypes/test.go
+++ b/test/reference/subtypes/test.go
@@ -1,0 +1,54 @@
+package reference
+
+import (
+	"gen/github.com/woven-planet/go-zserio/testdata/subtypes/schema"
+	"os"
+	"testing"
+
+	"github.com/bazelbuild/rules_go/go/tools/bazel"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	zserio "github.com/woven-planet/go-zserio"
+)
+
+func testWorkspace(t require.TestingT, filePath string) string {
+	actualPath, err := bazel.Runfile(filePath)
+	require.NoError(t, err)
+	return actualPath
+}
+
+// ReferenceFilePath is the path to the input data.
+var ReferenceFilePath string = os.Getenv("TESTDATA_BIN")
+
+func TestRoundTrip(t *testing.T) {
+	// Given
+	want, err := os.ReadFile(testWorkspace(t, ReferenceFilePath))
+	require.NoError(t, err)
+
+	// When
+	var object schema.DummyStruct
+	require.NoError(t, zserio.Unmarshal(want, &object), "unmarshal")
+	got, err := zserio.Marshal(&object)
+	require.NoError(t, err, "marshal")
+
+	// Then
+	assert.Equal(t, want, got)
+}
+
+func TestEqual(t *testing.T) {
+	// Given
+	bytes, err := os.ReadFile(testWorkspace(t, ReferenceFilePath))
+	require.NoError(t, err)
+
+	// When
+	var got schema.DummyStruct
+	require.NoError(t, zserio.Unmarshal(bytes, &got))
+
+	// Then
+	want := schema.DummyStruct{
+		Colour1: schema.ColourPurple,
+		Colour2: schema.SubtypedColourBlue,
+		Colour3: schema.OtherSubtypedColourOrange,
+	}
+	assert.Equal(t, want, got)
+}

--- a/test/reference/subtypes/test.go
+++ b/test/reference/subtypes/test.go
@@ -47,8 +47,8 @@ func TestEqual(t *testing.T) {
 	// Then
 	want := schema.DummyStruct{
 		Colour1: schema.ColourPurple,
-		Colour2: schema.SubtypedColourBlue,
-		Colour3: schema.OtherSubtypedColourOrange,
+		Colour2: schema.SubtypedColour(schema.ColourBlue),
+		Colour3: schema.OtherSubtypedColour(schema.ColourOrange),
 	}
 	assert.Equal(t, want, got)
 }


### PR DESCRIPTION
This issue was reported here: https://github.com/woven-planet/go-zserio/issues/108

To solve this issue, it is necessary to fully look up the original type of an expression, to remove all indirections caused by subtyping. Types such as enums that get type definition using the "subtype" type, require resolving the original type that was used. This code addresses this issue as follows:
1) If case of a dot expression, the code now looks up the original type,
   to remove subtype indirections.
2) Renamed / refactored the original type lookup a little bit. There is
   quite a bit of code duplication that should be further refactored
   (future work).
3) Renamed functions for better wording.

While adding a test case for this scenario, more issues in the code generation of subtyped Enums became obvious. I therefore added the code required to correctly generate subtyped Enum values, and properly switch between the original type and the subtyped in the expression generation:

Due to Go not supporting Enumerations, we need to check if subtyping is used.
instead of generating the Enumerationsvalue with the subtyped name, we need the
original type name.
For example, consider two Enumerations:

```
enum int Color {
    BLUE,
    RED,
};

subtype Color SubTypeColor;
```

When using the sub-typed enumeration SubTypeColor, we need to use the original Enum constants: instead of "SubTypeColorBlue", we want "ColorBlue", because only the latter one is defined in the generated Go code.

This makes it necessary to look up the original zserio type during code generation, search for the original constant, and cast it if needed.

Instead of generating `SubTypeColorBlue`, the code generation will generate `SubTypeColor(ColorBlue)`, which uses the original constant, and casts it to the subtype Enumeration type when needed.

