### PR TITLE
Add a Testcase to Validate Float Types Usage in Functions

### DIFF
--- a/test/struct_test.go
+++ b/test/struct_test.go
@@ -19,3 +19,10 @@ func TestOptionalField(t *testing.T) {
 	require.NoError(t, err)
 	require.Greater(t, len(dataWithOptional), len(dataWithoutOptional))
 }
+
+func TestZserioFunction(t *testing.T) {
+	// This test case ensures that the zserio functions were correctly generated,
+	// and the float types were correctly generated.
+	value := &types.ValueWrapper{Value: 1, F16Value: 0.5, F32Value: 1.5, F64Value: 10.0}
+	require.Equal(value.getSum(), 12.0)
+}

--- a/testdata/reference_modules/core/types.zs
+++ b/testdata/reference_modules/core/types.zs
@@ -27,10 +27,20 @@ struct ValueWrapper(int32 parameter)
     Color enumValue if parameter == 7;
     align(8):
     string description;
+
+    float16 f16Value;
+    float32 f32Value;
+    float64 f64Value;
     
     function int32 getValue()
     {
         return value + parameter;
+    }
+
+    function float64 getSum()
+    {
+        // Just some random additions and divisions.
+        return f16Value + f32Value + f64Value / (value << 2);
     }
 };
 

--- a/testdata/struct_optional_field.zs
+++ b/testdata/struct_optional_field.zs
@@ -1,4 +1,4 @@
-package struct_optional_field
+package struct_optional_field;
 
 enum uint8 State
 {


### PR DESCRIPTION
- This commit adds a test case that uses float variables in a zserio function to stress the different float type usages.
- It uses f16, f32 and f64 floats, mixed with integers, to challenge the generated code, to see if any missing-type-cast exceptions can be generated.