### PR TITLE
Support for the @index Operator

### DIFF
--- a/internal/generator/funcs.go
+++ b/internal/generator/funcs.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/woven-planet/go-zserio/internal/ast"
+	"github.com/woven-planet/go-zserio/internal/parser"
 )
 
 func IsDeltaPackable(scope ast.Scope, typ *ast.TypeReference) (bool, error) {
@@ -70,4 +71,34 @@ func GoNativeType(pkg *ast.Package, typ *ast.TypeReference) (*ast.OriginalTypeRe
 
 func Add(op1, op2 int) int {
 	return op1 + op2
+}
+
+func hasIndexOperator(expression *ast.Expression) bool {
+	if expression == nil {
+		return false
+	}
+
+	if hasIndexOperator(expression.Operand1) {
+		return true
+	}
+	if hasIndexOperator(expression.Operand2) {
+		return true
+	}
+	if hasIndexOperator(expression.Operand3) {
+		return true
+	}
+
+	if expression.Type == parser.ZserioParserINDEX {
+		return true
+	}
+	return false
+}
+
+func HasIndexOperators(typeRef *ast.TypeReference) bool {
+	for _, typeArgument := range typeRef.TypeArguments {
+		if hasIndexOperator(typeArgument) {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/generator/templates.go
+++ b/internal/generator/templates.go
@@ -15,16 +15,17 @@ var templates *template.Template
 func init() {
 	var err error
 	funcs := map[string]any{
-		"isDeltaPackable":  IsDeltaPackable,
-		"goType":           GoType,
-		"goPackageName":    GoPackageName,
-		"goGetAllImports":  GoGetAllImports,
-		"getTypeParameter": GetTypeParameter,
-		"goPackageAlias":   GoPackageAlias,
-		"goExpression":     GoExpression,
-		"goArrayTraits":    GoArrayTraits,
-		"goNativeType":     GoNativeType,
-		"add":              Add,
+		"isDeltaPackable":   IsDeltaPackable,
+		"goType":            GoType,
+		"goPackageName":     GoPackageName,
+		"goGetAllImports":   GoGetAllImports,
+		"getTypeParameter":  GetTypeParameter,
+		"goPackageAlias":    GoPackageAlias,
+		"goExpression":      GoExpression,
+		"goArrayTraits":     GoArrayTraits,
+		"goNativeType":      GoNativeType,
+		"add":               Add,
+		"hasIndexOperators": HasIndexOperators,
 	}
 
 	templates, err = template.New("generator").Funcs(sprig.TxtFuncMap()).Funcs(template.FuncMap(funcs)).ParseFS(content, "templates/*.go.tmpl")

--- a/internal/generator/templates/array_init.go.tmpl
+++ b/internal/generator/templates/array_init.go.tmpl
@@ -16,5 +16,18 @@
     {{ $field.Name }}ArrayProperties.IsAuto = true
 {{- end }}
 {{- if eq $traits "ztype.ObjectArrayTraits" }}
-    {{ $field.Name }}ArrayProperties.ArrayTraits.DefaultObject = new({{ goType $scope $native.Type }})
+    {{- $requireIndexedInit := hasIndexOperators $field.Type }}
+    {{ $field.Name }}ArrayProperties.ArrayTraits.ObjectCreator = ztype.ObjectCreator[*{{ goType $scope $native.Type }}] {
+    {{- if $requireIndexedInit }}
+        UsesIndexOperator: true,
+        DefaultObjects: []*{{ goType $scope $native.Type }}{},
+    {{- else }}
+        DefaultObject: new({{ goType $scope $native.Type }}),
+    {{- end }}
+    }
+    {{- if $requireIndexedInit }}
+    for index := 0; index < {{ $field.Name }}ArrayProperties.FixedSize; index++ {
+        {{ $field.Name }}ArrayProperties.ArrayTraits.ObjectCreator.DefaultObjects = append({{ $field.Name }}ArrayProperties.ArrayTraits.ObjectCreator.DefaultObjects, new({{ goType $scope $native.Type }}))
+    }
+    {{- end }}
 {{- end }}

--- a/internal/generator/templates/decode_compound_parameters.go.tmpl
+++ b/internal/generator/templates/decode_compound_parameters.go.tmpl
@@ -1,15 +1,28 @@
 
-{{ $scope := .pkg }}
-{{ $field := .field }}
+{{- $scope := .pkg }}
+{{- $field := .field }}
 {{- $field_name := .field_name }}
-
+{{- $use_index_operator := hasIndexOperators $field.Type }}
 {{- if $field.Type.TypeArguments }}
     {{- if $field.Array }}
-        {{- $field_name = printf "%sArrayProperties.ArrayTraits.DefaultObject" $field.Name }}
+        {{- if $use_index_operator }}
+// This array uses the index operator. The following for loop passes
+// all parameters to individual default objects. Since the @index
+// operator is used, each default object entry may look differently.
+for index, defaultObject := range {{ $field.Name }}ArrayProperties.ArrayTraits.ObjectCreator.DefaultObjects {
+          {{- $field_name = "defaultObject" }}
+        {{- else }}
+          {{- $field_name = printf "%sArrayProperties.ArrayTraits.ObjectCreator.DefaultObject" $field.Name }}
+        {{- end }}
     {{- end }}
     {{- $type_parameter := getTypeParameter $scope $field.Type }}
     {{- range $i, $argument := $field.Type.TypeArguments }}
         {{- $current_type_parameter := index $type_parameter $i }}
         {{ $field_name }}.{{ $current_type_parameter.Name}} = {{ goType $scope $current_type_parameter.Type }}({{ goExpression $scope $argument }})
     {{- end}}
+    {{- if and $field.Array $use_index_operator }}
+        {{- /* Close the for-loop again, if the index operator is used. */}}
+}
+    {{- end }}
+
 {{- end }}

--- a/test/reference/index_operator/BUILD.bazel
+++ b/test/reference/index_operator/BUILD.bazel
@@ -1,0 +1,48 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_test")
+load("//:rules.bzl", "go_zserio_library")
+load("//test/rules:rules.bzl", "py_zserio_library", "zs_payload")
+
+go_zserio_library(
+    name = "go_lib",
+    srcs = [":schema.zs"],
+    pkg = "index_operator.schema",
+    rootpackage = "gen/github.com/woven-planet/go-zserio/testdata",
+)
+
+py_zserio_library(
+    name = "py_lib",
+    outs = [
+        "index_operator/schema/__init__.py",
+        "index_operator/schema/api.py",
+        "index_operator/schema/block.py",
+        "index_operator/schema/block_header.py",
+        "index_operator/schema/index_operator.py",
+    ],
+    prefix = "testdata",
+    proto = ":schema.zs",
+)
+
+zs_payload(
+    name = "testdata",
+    srcs = ["data.py"],
+    out = "testdata.bin",
+    deps = [":py_lib"],
+)
+
+go_test(
+    name = "index_operator",
+    srcs = ["test.go"],
+    data = [
+        ":testdata",
+    ],
+    env = {
+        "TESTDATA_BIN": "$(rootpath :testdata)",
+    },
+    deps = [
+        ":go_lib",
+        "//:go-zserio",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+        "@io_bazel_rules_go//go/tools/bazel:go_default_library",
+    ],
+)

--- a/test/reference/index_operator/data.py
+++ b/test/reference/index_operator/data.py
@@ -1,0 +1,34 @@
+from testdata.index_operator.schema.api import IndexOperator, Block, BlockHeader
+
+
+def new():
+    headers: list[BlockHeader] = [
+        BlockHeader(num_items_=3),
+        BlockHeader(num_items_=0),
+        BlockHeader(num_items_=1),
+    ]
+
+    array = IndexOperator(
+        num_blocks_=3,
+        headers_=headers,
+        blocks_=[
+            Block(
+                header_=headers[0],
+                items_=[1, 2, 3],
+                condition_item_=100,
+            ),            
+            Block(
+				header_=headers[1],
+                # len(items_) is 0, since BlockHeader.num_items_ is 0.
+				# For the same reason, condition_item_ won't be serialized.
+                items_=[],
+                condition_item_=1234, # This value should be ignored.
+            ),
+            Block(
+                header_=headers[2],
+                items_=[10],
+                condition_item_=200,
+            ),
+        ]
+    )
+    return array

--- a/test/reference/index_operator/schema.zs
+++ b/test/reference/index_operator/schema.zs
@@ -1,0 +1,24 @@
+package index_operator.schema;
+
+
+// This is a simple testcase to test the @index operator.
+struct IndexOperator
+{
+    uint16                  numBlocks;
+    BlockHeader             headers[numBlocks];
+    Block(headers[@index])  blocks[numBlocks];
+};
+
+struct BlockHeader
+{
+    uint16 numItems;
+};
+
+struct Block(BlockHeader header)
+{
+    int64 items[header.numItems];
+
+    // Add a conditional item, that depends on the parameter passed in the index.
+    // This ensures that during serialization / deserialization, the item is correctly passed.
+    uint8 conditionItem if lengthof(items) > 0;
+};

--- a/test/reference/index_operator/test.go
+++ b/test/reference/index_operator/test.go
@@ -1,0 +1,82 @@
+package reference
+
+import (
+	"gen/github.com/woven-planet/go-zserio/testdata/index_operator/schema"
+	"os"
+	"testing"
+
+	"github.com/bazelbuild/rules_go/go/tools/bazel"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	zserio "github.com/woven-planet/go-zserio"
+)
+
+func testWorkspace(t require.TestingT, filePath string) string {
+	actualPath, err := bazel.Runfile(filePath)
+	require.NoError(t, err)
+	return actualPath
+}
+
+// ReferenceFilePath is the path to the input data.
+var ReferenceFilePath string = os.Getenv("TESTDATA_BIN")
+
+func TestRoundTrip(t *testing.T) {
+	// Given
+	want, err := os.ReadFile(testWorkspace(t, ReferenceFilePath))
+	require.NoError(t, err)
+
+	// When
+	var object schema.IndexOperator
+	require.NoError(t, zserio.Unmarshal(want, &object), "unmarshal")
+	got, err := zserio.Marshal(&object)
+	require.NoError(t, err, "marshal")
+
+	// Then
+	assert.Equal(t, want, got)
+}
+
+func TestEqual(t *testing.T) {
+	// Given
+	bytes, err := os.ReadFile(testWorkspace(t, ReferenceFilePath))
+	require.NoError(t, err)
+
+	// When
+	var got schema.IndexOperator
+	require.NoError(t, zserio.Unmarshal(bytes, &got))
+
+	// Then
+	want_headers := []schema.BlockHeader{
+		{
+			NumItems: 3,
+		},
+		{
+			NumItems: 0,
+		},
+		{
+			NumItems: 1,
+		},
+	}
+	want := schema.IndexOperator{
+		NumBlocks: 3,
+		Headers:   want_headers,
+		Blocks: []schema.Block{
+			{
+				Header:        want_headers[0],
+				Items:         []int64{1, 2, 3},
+				ConditionItem: 100,
+			},
+			{
+				Header: want_headers[1],
+				// len(Items) is 0, since BlockHeader.NumItems is 0.
+				// For the same reason, ConditionItem won't be serialized.
+				Items: []int64{},
+			},
+			{
+				Header:        want_headers[2],
+				Items:         []int64{10},
+				ConditionItem: 200,
+			},
+		},
+	}
+	assert.Equal(t, want, got)
+}

--- a/ztype/array_traits.go
+++ b/ztype/array_traits.go
@@ -34,7 +34,7 @@ type IArrayTraits[T any] interface {
 	InitializeOffsets(bitPosition int, value T) int
 
 	// Read reads an array element from a byte stream.
-	Read(reader zserio.Reader, endBitPosition int) (T, error)
+	Read(reader zserio.Reader, index int) (T, error)
 
 	// Write writes an array element to a byte stream.
 	Write(writer zserio.Writer, value T) error
@@ -79,7 +79,7 @@ func (trait Float16ArrayTraits) InitializeOffsets(bitPosition int, value float32
 	return bitPosition + trait.BitSizeOf(value, 0)
 }
 
-func (trait Float16ArrayTraits) Read(reader zserio.Reader, endBitPosition int) (float32, error) {
+func (trait Float16ArrayTraits) Read(reader zserio.Reader, index int) (float32, error) {
 	return ReadFloat16(reader)
 }
 
@@ -124,7 +124,7 @@ func (trait Float32ArrayTraits) InitializeOffsets(bitPosition int, value float32
 	return bitPosition + trait.BitSizeOf(value, 0) // endBitPosition is ignored
 }
 
-func (trait Float32ArrayTraits) Read(reader zserio.Reader, endBitPosition int) (float32, error) {
+func (trait Float32ArrayTraits) Read(reader zserio.Reader, index int) (float32, error) {
 	return ReadFloat32(reader)
 }
 
@@ -169,7 +169,7 @@ func (trait Float64ArrayTraits) InitializeOffsets(bitPosition int, value float64
 	return bitPosition + trait.BitSizeOf(value, 0)
 }
 
-func (trait Float64ArrayTraits) Read(reader zserio.Reader, endBitPosition int) (float64, error) {
+func (trait Float64ArrayTraits) Read(reader zserio.Reader, index int) (float64, error) {
 	return ReadFloat64(reader)
 }
 
@@ -220,7 +220,7 @@ func (trait VarIntArrayTraits) InitializeOffsets(bitPosition int, value int64) i
 	return bitPosition + trait.BitSizeOf(value, 0)
 }
 
-func (trait VarIntArrayTraits) Read(reader zserio.Reader, endBitPosition int) (int64, error) {
+func (trait VarIntArrayTraits) Read(reader zserio.Reader, index int) (int64, error) {
 	return ReadVarint(reader)
 }
 
@@ -267,7 +267,7 @@ func (trait VarInt16ArrayTraits) InitializeOffsets(bitPosition int, value int16)
 	return bitPosition + trait.BitSizeOf(value, 0) // endBitPosition is ignored
 }
 
-func (trait VarInt16ArrayTraits) Read(reader zserio.Reader, endBitPosition int) (int16, error) {
+func (trait VarInt16ArrayTraits) Read(reader zserio.Reader, index int) (int16, error) {
 	return ReadVarint16(reader)
 }
 
@@ -314,7 +314,7 @@ func (trait VarInt32ArrayTraits) InitializeOffsets(bitPosition int, value int32)
 	return bitPosition + trait.BitSizeOf(value, 0) // endBitPosition is ignored
 }
 
-func (trait VarInt32ArrayTraits) Read(reader zserio.Reader, endBitPosition int) (int32, error) {
+func (trait VarInt32ArrayTraits) Read(reader zserio.Reader, index int) (int32, error) {
 	return ReadVarint32(reader)
 }
 
@@ -361,7 +361,7 @@ func (trait VarInt64ArrayTraits) InitializeOffsets(bitPosition int, value int64)
 	return bitPosition + trait.BitSizeOf(value, 0) // endBitPosition is ignored
 }
 
-func (trait VarInt64ArrayTraits) Read(reader zserio.Reader, endBitPosition int) (int64, error) {
+func (trait VarInt64ArrayTraits) Read(reader zserio.Reader, index int) (int64, error) {
 	return ReadVarint64(reader)
 }
 
@@ -408,7 +408,7 @@ func (trait VarUInt16ArrayTraits) InitializeOffsets(bitPosition int, value uint1
 	return bitPosition + trait.BitSizeOf(value, 0) // endBitPosition is ignored
 }
 
-func (trait VarUInt16ArrayTraits) Read(reader zserio.Reader, endBitPosition int) (uint16, error) {
+func (trait VarUInt16ArrayTraits) Read(reader zserio.Reader, index int) (uint16, error) {
 	return ReadVaruint16(reader)
 }
 
@@ -454,7 +454,7 @@ func (trait VarUInt32ArrayTraits) InitializeOffsets(bitPosition int, value uint3
 	return bitPosition + trait.BitSizeOf(value, 0) // endBitPosition is ignored
 }
 
-func (trait VarUInt32ArrayTraits) Read(reader zserio.Reader, endBitPosition int) (uint32, error) {
+func (trait VarUInt32ArrayTraits) Read(reader zserio.Reader, index int) (uint32, error) {
 	return ReadVaruint32(reader)
 }
 
@@ -500,7 +500,7 @@ func (trait VarUInt64ArrayTraits) InitializeOffsets(bitPosition int, value uint6
 	return bitPosition + trait.BitSizeOf(value, 0) // endBitPosition is ignored
 }
 
-func (trait VarUInt64ArrayTraits) Read(reader zserio.Reader, endBitPosition int) (uint64, error) {
+func (trait VarUInt64ArrayTraits) Read(reader zserio.Reader, index int) (uint64, error) {
 	return ReadVaruint64(reader)
 }
 
@@ -545,7 +545,7 @@ func (trait VarUIntArrayTraits) InitializeOffsets(bitPosition int, value uint64)
 	return bitPosition + trait.BitSizeOf(value, 0) // endBitPosition is ignored
 }
 
-func (trait VarUIntArrayTraits) Read(reader zserio.Reader, endBitPosition int) (uint64, error) {
+func (trait VarUIntArrayTraits) Read(reader zserio.Reader, index int) (uint64, error) {
 	return ReadVaruint(reader)
 }
 
@@ -590,7 +590,7 @@ func (trait VarSizeArrayTraits) InitializeOffsets(bitPosition int, value uint64)
 	return bitPosition + trait.BitSizeOf(value, 0) // endBitPosition is ignored
 }
 
-func (trait VarSizeArrayTraits) Read(reader zserio.Reader, endBitPosition int) (uint64, error) {
+func (trait VarSizeArrayTraits) Read(reader zserio.Reader, index int) (uint64, error) {
 	return ReadVarsize(reader)
 }
 
@@ -636,7 +636,7 @@ func (trait BitFieldArrayTraits[T]) InitializeOffsets(bitPosition int, value T) 
 	return bitPosition + trait.BitSizeOf(value, 0) // endBitPosition is ignored
 }
 
-func (trait BitFieldArrayTraits[T]) Read(reader zserio.Reader, endBitPosition int) (T, error) {
+func (trait BitFieldArrayTraits[T]) Read(reader zserio.Reader, index int) (T, error) {
 	value, err := reader.ReadBits(uint8(trait.NumBits))
 	return T(value), err
 }
@@ -697,7 +697,7 @@ func (trait SignedBitFieldArrayTraits[T]) InitializeOffsets(bitPosition int, val
 	return bitPosition + trait.BitSizeOf(value, 0) // endBitPosition is ignored
 }
 
-func (trait SignedBitFieldArrayTraits[T]) Read(reader zserio.Reader, endBitPosition int) (T, error) {
+func (trait SignedBitFieldArrayTraits[T]) Read(reader zserio.Reader, index int) (T, error) {
 	value, err := reader.ReadBits(uint8(trait.NumBits))
 	return T(fillUpperBits(value, trait.NumBits)), err
 }
@@ -744,7 +744,7 @@ func (trait BooleanArrayTraits) InitializeOffsets(bitPosition int, value bool) i
 	return bitPosition + trait.BitSizeOf(value, 0) // endBitPosition is ignored
 }
 
-func (trait BooleanArrayTraits) Read(reader zserio.Reader, endBitPosition int) (bool, error) {
+func (trait BooleanArrayTraits) Read(reader zserio.Reader, index int) (bool, error) {
 	return ReadBool(reader)
 }
 
@@ -800,7 +800,7 @@ func (trait StringArrayTraits) InitializeOffsets(bitPosition int, value string) 
 	return bitPosition + trait.BitSizeOf(value, 0) // endBitPosition is ignored
 }
 
-func (trait StringArrayTraits) Read(reader zserio.Reader, endBitPosition int) (string, error) {
+func (trait StringArrayTraits) Read(reader zserio.Reader, index int) (string, error) {
 	return ReadString(reader)
 }
 
@@ -904,15 +904,24 @@ func (trait BytesArrayTraits) FromUint64(value uint64) *BytesType {
 	return nil // not supported for Extern type objects
 }
 
+type ObjectCreator[T zserio.PackableZserioType] struct {
+	DefaultObject T
+
+	// If the @index operator is used, we need to store multiple default objects.
+	DefaultObjects []T
+
+	UsesIndexOperator bool
+}
+
 // ObjectArrayTraits is an array traits for zserio structs, choice, union or enum types
 type ObjectArrayTraits[T zserio.PackableZserioType] struct {
-	DefaultObject T
+	ObjectCreator ObjectCreator[T]
 }
 
 func (trait ObjectArrayTraits[T]) PackedTraits() IPackedArrayTraits[T] {
 	return &ObjectPackedArrayTraits[T, ObjectArrayTraits[T]]{
 		ArrayTraits:   trait,
-		DefaultObject: trait.DefaultObject,
+		ObjectCreator: trait.ObjectCreator,
 	}
 }
 
@@ -938,8 +947,16 @@ func (trait ObjectArrayTraits[T]) InitializeOffsets(bitPosition int, value T) in
 	return offset
 }
 
-func (trait ObjectArrayTraits[T]) Read(reader zserio.Reader, endBitPosition int) (T, error) {
-	value := trait.DefaultObject.Clone().(T)
+func (trait ObjectArrayTraits[T]) Read(reader zserio.Reader, index int) (T, error) {
+	// For arrays that uses the index operator, each array element
+	// will have a different initialization (because each array
+	// element will have different parameters).
+	var value T
+	if trait.ObjectCreator.UsesIndexOperator {
+		value = trait.ObjectCreator.DefaultObjects[index]
+	} else {
+		value = trait.ObjectCreator.DefaultObject.Clone().(T)
+	}
 	err := value.UnmarshalZserio(reader)
 	return value, err
 }


### PR DESCRIPTION
This resolves https://github.com/woven-planet/go-zserio/issues/115. 

The index operator is used for arrays, with the purpose of linking two arrays with each other: one array serves as the input parameters of another list, and each element in the input array matches to one element in the output array.

`@index` operators were so far not supported. This PR fixes that by:
- implementing the possibility in the object array traits to initialize each array element with individual parameters (by using multiple `DefaultObjects` instead of one `DefaultObject`). This makes it possible to initialize each array element individually, if the index operator is used.
- A test case was added which uses the index operator, and verifies that the parameter passing works as expected.

I recommend to understand the test case first, before looking into the implementation details, as I feel the index operator can be quite confusing.