### PR TITLE
Explicitly declare the Numeral Type in Bitshift Operations

### DIFF
--- a/test/reference/bitshift_operator/BUILD.bazel
+++ b/test/reference/bitshift_operator/BUILD.bazel
@@ -1,0 +1,46 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_test")
+load("//:rules.bzl", "go_zserio_library")
+load("//test/rules:rules.bzl", "py_zserio_library", "zs_payload")
+
+go_zserio_library(
+    name = "go_lib",
+    srcs = [":schema.zs"],
+    pkg = "bitshift_operator.schema",
+    rootpackage = "gen/github.com/woven-planet/go-zserio/testdata",
+)
+
+py_zserio_library(
+    name = "py_lib",
+    outs = [
+        "bitshift_operator/schema/__init__.py",
+        "bitshift_operator/schema/api.py",
+        "bitshift_operator/schema/bit_shift_operator.py",
+    ],
+    prefix = "testdata",
+    proto = ":schema.zs",
+)
+
+zs_payload(
+    name = "testdata",
+    srcs = ["data.py"],
+    out = "testdata.bin",
+    deps = [":py_lib"],
+)
+
+go_test(
+    name = "bitshift_operator",
+    srcs = ["test.go"],
+    data = [
+        ":testdata",
+    ],
+    env = {
+        "TESTDATA_BIN": "$(rootpath :testdata)",
+    },
+    deps = [
+        ":go_lib",
+        "//:go-zserio",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+        "@io_bazel_rules_go//go/tools/bazel:go_default_library",
+    ],
+)

--- a/test/reference/bitshift_operator/data.py
+++ b/test/reference/bitshift_operator/data.py
@@ -1,0 +1,8 @@
+from testdata.bitshift_operator.schema.api import BitShiftOperator
+
+
+def new() -> BitShiftOperator:
+    return BitShiftOperator(
+        u8_bit_shift_=2,
+        f64_value_=35.55,
+    )

--- a/test/reference/bitshift_operator/schema.zs
+++ b/test/reference/bitshift_operator/schema.zs
@@ -1,0 +1,12 @@
+package bitshift_operator.schema;
+
+struct BitShiftOperator
+{
+    uint8 u8BitShift;
+    float64 f64Value;
+
+    function float64 testBitShift()
+    {
+        return (1 << u8BitShift) + f64Value;
+    }
+};

--- a/test/reference/bitshift_operator/schema.zs
+++ b/test/reference/bitshift_operator/schema.zs
@@ -7,6 +7,8 @@ struct BitShiftOperator
 
     function float64 testBitShift()
     {
+        // This test case validates the correct generation of bitshift expressions.
+        // See https://github.com/woven-planet/go-zserio/pull/123.
         return (1 << u8BitShift) + f64Value;
     }
 };

--- a/test/reference/bitshift_operator/test.go
+++ b/test/reference/bitshift_operator/test.go
@@ -1,0 +1,53 @@
+package reference
+
+import (
+	"gen/github.com/woven-planet/go-zserio/testdata/bitshift_operator/schema"
+	"os"
+	"testing"
+
+	"github.com/bazelbuild/rules_go/go/tools/bazel"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	zserio "github.com/woven-planet/go-zserio"
+)
+
+func testWorkspace(t require.TestingT, filePath string) string {
+	actualPath, err := bazel.Runfile(filePath)
+	require.NoError(t, err)
+	return actualPath
+}
+
+// ReferenceFilePath is the path to the input data.
+var ReferenceFilePath string = os.Getenv("TESTDATA_BIN")
+
+func TestRoundTrip(t *testing.T) {
+	// Given
+	want, err := os.ReadFile(testWorkspace(t, ReferenceFilePath))
+	require.NoError(t, err)
+
+	// When
+	var object schema.BitShiftOperator
+	require.NoError(t, zserio.Unmarshal(want, &object), "unmarshal")
+	got, err := zserio.Marshal(&object)
+	require.NoError(t, err, "marshal")
+
+	// Then
+	assert.Equal(t, want, got)
+}
+
+func TestEqual(t *testing.T) {
+	// Given
+	bytes, err := os.ReadFile(testWorkspace(t, ReferenceFilePath))
+	require.NoError(t, err)
+
+	// When
+	var got schema.BitShiftOperator
+	require.NoError(t, zserio.Unmarshal(bytes, &got))
+
+	// Then
+	want := schema.BitShiftOperator{
+		U8BitShift: 2,
+		F64Value:   35.55,
+	}
+	assert.Equal(t, want, got)
+}


### PR DESCRIPTION
With https://github.com/woven-planet/go-zserio/pull/121 implemented, some bitshift operations start to generate invalid Go code. For example, the following generated code does not compile:

`float64((1 << v.NumBits) - 1)`
The compiler gives an error: `invalid operation: shifted operand 1 (type float64) must be integer`

To solve this issue, we need to explicitly specify the type, if the left operand in a bitshift operation is a numeral.

This PR fixes this issue, by generating
`float64((uint32(1) << v.NumBits) - 1)`
instead.

Also see https://github.com/golang/go/issues/19963 for more details on this issue.