### PR TITLE
simplify range expressions

### DIFF
--- a/internal/generator/templates/bitsizeof.go.tmpl
+++ b/internal/generator/templates/bitsizeof.go.tmpl
@@ -32,7 +32,7 @@
 {{- if $field.Array }}
     {{- template "array_init.go.tmpl" dict "pkg" $scope "field_name" $name "field" $field "native" $native }}
     {{- if $native.IsMarshaler }}
-    for index, _ := range {{ $name }} {
+    for index := range {{ $name }} {
         {{ $field.Name }}ArrayProperties.RawArray = append({{ $field.Name }}ArrayProperties.RawArray, {{if $native.RequiresCast }}(*{{ goType $scope $native.Type }})(&{{ $name }}[index]){{ else }}&{{ $name }}[index]{{ end }})
     }
     {{- else if $native.RequiresCast }}

--- a/internal/generator/templates/encode.go.tmpl
+++ b/internal/generator/templates/encode.go.tmpl
@@ -44,7 +44,7 @@
         }
     {{- end }}
     {{- if $native.IsMarshaler }}
-        for index, _ := range {{ $field_name }} {
+        for index := range {{ $field_name }} {
             {{ $field.Name }}ArrayProperties.RawArray = append({{ $field.Name }}ArrayProperties.RawArray, {{if $native.RequiresCast }}(*{{ goType $scope $native.Type }})(&{{ $field_name }}[index]){{ else }}&{{ $field_name }}[index]{{ end }})
         }
     {{- else if $native.RequiresCast }}

--- a/internal/generator/templates/encode_compound_parameters.go.tmpl
+++ b/internal/generator/templates/encode_compound_parameters.go.tmpl
@@ -5,7 +5,7 @@
 
 {{- if $field.Type.TypeArguments }}
     {{- if $field.Array }}
-        for index, _ := range {{ $field_name }} {
+        for index := range {{ $field_name }} {
         {{- $field_name = printf "%s[index]" $field_name }}
     {{- end }}
     {{- $type_parameter := getTypeParameter $scope $field.Type }}

--- a/internal/generator/templates/packing_context_bitsize.go.tmpl
+++ b/internal/generator/templates/packing_context_bitsize.go.tmpl
@@ -31,7 +31,7 @@
 {{- if $field.Array }}
     {{- template "array_init.go.tmpl" dict "pkg" $scope "field_name" $field_name "field" $field "native" $native }}
     {{- if $native.IsMarshaler }}
-    for index, _ := range {{ $field_name }} {
+    for index := range {{ $field_name }} {
         {{ $field.Name }}ArrayProperties.RawArray = append({{ $field.Name }}ArrayProperties.RawArray, {{if $native.RequiresCast }}(*{{ goType $scope $native.Type }})(&{{ $field_name }}[index]){{ else }}&{{ $field_name }}[index]{{ end }})
     }
     {{- else if $native.RequiresCast }}

--- a/internal/generator/templates/packing_context_encode.go.tmpl
+++ b/internal/generator/templates/packing_context_encode.go.tmpl
@@ -54,7 +54,7 @@
         {{ $field.Name }}ArrayProperties.IsPacked = true
     {{- end }}
     {{- if $native.IsMarshaler }}
-        for index, _ := range {{ $field_name }} {
+        for index := range {{ $field_name }} {
             {{ $field.Name }}ArrayProperties.RawArray = append({{ $field.Name }}ArrayProperties.RawArray, {{if $native.RequiresCast }}(*{{ goType $scope $native.Type }})(&{{ $field_name }}[index]){{ else }}&{{ $field_name }}[index]{{ end }})
         }
     {{- else if $native.RequiresCast }}


### PR DESCRIPTION
This should eliminate the "simplify range expression" linter warnings that pollute the vscode problems view..

![image](https://github.com/woven-planet/go-zserio/assets/10351272/9c7ca79e-03eb-4577-a1f2-41820a126b37)


Jochen Mehlhorn <jochen.mehlhorn@mercedes-benz.com>, Mercedes-Benz Tech Innovation GmbH

[Provider Information](https://github.com/Daimler/daimler-foss/blob/master/PROVIDER_INFORMATION.md)