### PR TITLE
doc(goroot): fix contributing guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,10 +54,15 @@ pre-commit installed at .git/hooks/pre-commit
 
 ## Visual Studio Code
 
+In order to setup the tools called by the editor, run:
+
+```console
+bazel run //:bazel_env
+```
+
 In order for [VS Code](https://code.visualstudio.com) you will need to configure
 it to use a bazel-aware _gopackagesdriver_ with the gopls language server. To do
-that use the following for `.vscode/settings.json`, replacing
-`/Users/wichert/Code/go-zserio` with the correct location on your machine.
+that use the following for `.vscode/settings.json`:
 
 ```json
 {

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,9 +61,9 @@ that use the following for `.vscode/settings.json`, replacing
 
 ```json
 {
-  "go.goroot": "/Users/wichert/Code/go-zserio/bazel-go-zserio/external/go_sdk",
+  "go.goroot": "{workspaceFolder}/bazel-out/bazel_env-opt/bin/bazel_env/bin/go.runfiles/rules_go~~go_sdk~go-zserio-go-sdk",
   "go.toolsEnvVars": {
-    "GOPACKAGESDRIVER": "/Users/wichert/Code/go-zserio/bazel-out/bazel_env-opt/bin/bazel_env/bin/gopackagesdriver.sh"
+    "GOPACKAGESDRIVER": "{workspaceFolder}/bazel-out/bazel_env-opt/bin/bazel_env/bin/gopackagesdriver.sh"
   },
   "go.enableCodeLens": {
     "references": false,

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -26,7 +26,10 @@ pip.parse(
 use_repo(pip, "pip")
 
 go_sdk = use_extension("@rules_go//go:extensions.bzl", "go_sdk")
-go_sdk.download(version = "1.21.7")
+go_sdk.download(
+    name = "go-zserio-go-sdk",
+    version = "1.21.7",
+)
 
 go_deps = use_extension("@gazelle//:extensions.bzl", "go_deps")
 go_deps.from_file(go_mod = "//:go.mod")


### PR DESCRIPTION
Fix the documentation and name the downloaded SDK with a stable name to make
the documentation less reliant on the `bzlmod` and `rules_go` implementation
details.
