### PR TITLE
Slice initialization

### DIFF
--- a/internal/generator/templates/decode.go.tmpl
+++ b/internal/generator/templates/decode.go.tmpl
@@ -69,6 +69,7 @@
             {{- if $native.IsMarshaler }}
                 {{- $element = "*elem" }}
             {{- end }}
+            {{ $assign_str_lvalue }} = make([]{{ if $native.RequiresCast }}{{ goType $scope $field.Type }}{{ else }}{{ goType $scope $native.Type }}{{ end }}, 0, len({{ $field.Name }}ArrayProperties.RawArray))
             for _, elem := range {{ $field.Name }}ArrayProperties.RawArray {
                 {{ $assign_str_lvalue }} = append({{ $assign_str_lvalue }}, {{ if $native.RequiresCast }}{{ goType $scope $field.Type }}({{ $element }}){{ else }}{{ $element }}{{ end }})
             }


### PR DESCRIPTION
Hi again,

seems like I missed a spot where we benefit from slice initialization. 
Without this change I could barely measure a relevant difference, but with this change included I see ~6-8% performance improvements during decoding of display tiles (many roads, polygons, etc.) in a go benchmark.
Depends on how large the arrays are, I suppose.

Cheers,
Jochen



The program was tested solely for our own use cases, which might differ from yours.

Jochen Mehlhorn <jochen.mehlhorn@mercedes-benz.com>, Mercedes-Benz Tech Innovation GmbH

[Provider Information](https://github.com/Daimler/daimler-foss/blob/master/PROVIDER_INFORMATION.md)
