### PR TITLE
Fix broken vscode variable in CONTRIBUTING docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,9 +66,9 @@ that use the following for `.vscode/settings.json`:
 
 ```json
 {
-  "go.goroot": "{workspaceFolder}/bazel-out/bazel_env-opt/bin/bazel_env/bin/go.runfiles/rules_go~~go_sdk~go-zserio-go-sdk",
+  "go.goroot": "${workspaceFolder}/bazel-out/bazel_env-opt/bin/bazel_env/bin/go.runfiles/rules_go~~go_sdk~go-zserio-go-sdk",
   "go.toolsEnvVars": {
-    "GOPACKAGESDRIVER": "{workspaceFolder}/bazel-out/bazel_env-opt/bin/bazel_env/bin/gopackagesdriver.sh"
+    "GOPACKAGESDRIVER": "${workspaceFolder}/bazel-out/bazel_env-opt/bin/bazel_env/bin/gopackagesdriver.sh"
   },
   "go.enableCodeLens": {
     "references": false,


### PR DESCRIPTION
CONTRIBUTING Docs were missing the dollar sign which caused broken Go tooling due to "file not found" error.



The program was tested solely for our own use cases, which might differ from yours.

Jochen Mehlhorn <jochen.mehlhorn@mercedes-benz.com>, Mercedes-Benz Tech Innovation GmbH

[Provider Information](https://github.com/Daimler/daimler-foss/blob/master/PROVIDER_INFORMATION.md)