### PR TITLE
Handle partial reads from Reader

### DIFF
--- a/test/BUILD.bazel
+++ b/test/BUILD.bazel
@@ -23,6 +23,7 @@ go_test(
     deps = [
         "//:go-zserio",
         "//testdata/reference_modules:go_core_types",
+        "//zstream",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
     ],

--- a/test/struct_test.go
+++ b/test/struct_test.go
@@ -1,12 +1,15 @@
 package reference
 
 import (
+	"bufio"
+	"bytes"
 	"gen/github.com/woven-planet/go-zserio/testdata/reference_modules/core/types"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
 	zserio "github.com/woven-planet/go-zserio"
+	"github.com/woven-planet/go-zserio/zstream"
 )
 
 func TestOptionalField(t *testing.T) {
@@ -44,4 +47,29 @@ func TestGoIntegerTypeCasts(t *testing.T) {
 		I32ValueArray: []int32{-1, -2, -3, -4, -5},
 	}
 	require.Equal(t, (float32)(11320.0), value.TestTypeCasts())
+}
+
+func TestShortRead(t *testing.T) {
+	input := types.ValueWrapper{
+		Value:         1,
+		Description:   "this is a string that is larger than the buffer size",
+		Vari16Value:   16,
+		Vari32Value:   32,
+		Vari64Value:   64,
+		VariValue:     -33,
+		Varu16Value:   1,
+		Varu32Value:   0,
+		Varu64Value:   353,
+		VaruValue:     6457,
+		VarSizeValue:  4425,
+		I32ValueArray: []int32{-1, -2, -3, -4, -5},
+	}
+	data, err := zserio.Marshal(&input)
+	require.Nil(t, err, "zserio marshalling failed")
+	buf := bytes.NewBuffer(data)
+	reader := zstream.NewReader(bufio.NewReaderSize(buf, 16))
+	var got types.ValueWrapper
+	got.UnmarshalZserio(reader)
+	require.Nil(t, err, "zserio unmarshalling failed")
+	require.Equal(t, input, got)
 }

--- a/ztype/bytes_decode.go
+++ b/ztype/bytes_decode.go
@@ -2,6 +2,7 @@ package ztype
 
 import (
 	"errors"
+	"io"
 
 	zserio "github.com/woven-planet/go-zserio"
 )
@@ -16,7 +17,7 @@ func ReadBytes(r zserio.Reader) (*BytesType, error) {
 	}
 
 	b.Buffer = make([]byte, b.ByteSize)
-	n, err := r.Read(b.Buffer)
+	n, err := io.ReadFull(r, b.Buffer)
 	if err != nil {
 		return nil, err
 	}

--- a/ztype/extern_decode.go
+++ b/ztype/extern_decode.go
@@ -2,6 +2,7 @@ package ztype
 
 import (
 	"errors"
+	"io"
 
 	zserio "github.com/woven-planet/go-zserio"
 )
@@ -17,8 +18,8 @@ func ReadExtern(r zserio.Reader) (*ExternType, error) {
 	numOfFullBytes := int(e.BitSize / 8)
 	remainingBits := uint8(e.BitSize % 8)
 
-	e.Buffer = make([]byte, numOfFullBytes)
-	n, err := r.Read(e.Buffer)
+	e.Buffer = make([]byte, numOfFullBytes, numOfFullBytes+1)
+	n, err := io.ReadFull(r, e.Buffer)
 	if err != nil {
 		return nil, err
 	}

--- a/ztype/string_decode.go
+++ b/ztype/string_decode.go
@@ -1,6 +1,10 @@
 package ztype
 
-import zserio "github.com/woven-planet/go-zserio"
+import (
+	"io"
+
+	zserio "github.com/woven-planet/go-zserio"
+)
 
 // ReadString reads a string from the bitstream.
 func ReadString(r zserio.Reader) (string, error) {
@@ -9,7 +13,7 @@ func ReadString(r zserio.Reader) (string, error) {
 		return "", err
 	}
 	buf := make([]byte, size)
-	if _, err = r.Read(buf); err != nil {
+	if _, err = io.ReadFull(r, buf); err != nil {
 		return "", err
 	}
 	return string(buf), nil


### PR DESCRIPTION
In some cases, for example when using bufio.Reader, a Read may return partial data. This was causing problems for ExternData, bytes and string types.

fixes #145
fixes #147
