### PR TITLE
Always check for alignment errors

### DIFF
--- a/internal/generator/templates/decode.go.tmpl
+++ b/internal/generator/templates/decode.go.tmpl
@@ -25,7 +25,9 @@
     if {{ goExpression $scope $field.OptionalClause }} {
 {{- end }}
 {{- if not (eq $field.Alignment 0) }}
-    r.Align({{ $field.Alignment }})
+    if _, err = r.Align({{ $field.Alignment }}); err != nil {
+        return err
+    }
 {{- end }}
 
 {{- $assign_str_lvalue := printf "v.%s" $field.Name }}

--- a/internal/generator/templates/packing_context_decode.go.tmpl
+++ b/internal/generator/templates/packing_context_decode.go.tmpl
@@ -43,7 +43,9 @@
 {{- end }}
 
 {{- if not (eq $field.Alignment 0) }}
-    r.Align({{ $field.Alignment }})
+    if _, err = r.Align({{ $field.Alignment }}); err != nil {
+        return err
+    }
 {{- end }}
 
 {{- if $field.Array }}


### PR DESCRIPTION
Not all generated code that needed bitstream alignment was checking for
errors from the Align call.

fixes #146
