### PR TITLE
Improve DeltaContext previousElement handling

### DIFF
--- a/ztype/array.go
+++ b/ztype/array.go
@@ -12,24 +12,24 @@ type Array[T any, Y IArrayTraits[T]] struct {
 	// ArrayTraits are the array traits used.
 	ArrayTraits Y
 
-	// RawArray is a reference to the raw array.
-	RawArray []T
-
-	// IsAuto specifies if the array size is automatically calculated.
-	IsAuto bool
-
-	// IsPacked specifies if the array is packed.
-	IsPacked bool
-
-	// FixedSize is the size of the array, if the array is of fixed size
-	FixedSize int
-
 	// The node used by this array for packing
 	PackedContext *zserio.PackingContextNode
 
 	// SetOffsetMethod is an optional function to set the offset to the buffer.
 	setOffsetMethod   OffsetMethod
 	checkOffsetMethod OffsetMethod
+
+	// RawArray is a reference to the raw array.
+	RawArray []T
+
+	// FixedSize is the size of the array, if the array is of fixed size
+	FixedSize int
+
+	// IsAuto specifies if the array size is automatically calculated.
+	IsAuto bool
+
+	// IsPacked specifies if the array is packed.
+	IsPacked bool
 }
 
 // Size returns the number of elements in an array.

--- a/ztype/bytes.go
+++ b/ztype/bytes.go
@@ -2,9 +2,9 @@ package ztype
 
 // BytesType is a helper struct to store byte blobs in zserio
 type BytesType struct {
-	// BitSize is the size of the buffer in bytes
-	ByteSize uint64
-
 	// Buffer is the content of the zserio byte type
 	Buffer []byte
+
+	// BitSize is the size of the buffer in bytes
+	ByteSize uint64
 }

--- a/ztype/extern.go
+++ b/ztype/extern.go
@@ -2,9 +2,9 @@ package ztype
 
 // ExternType is a helper struct to store zserio extern types
 type ExternType struct {
-	// BitSize is the size of the buffer in bits
-	BitSize uint64
-
 	// Buffer is the content of the zserio extern type
 	Buffer []byte
+
+	// BitSize is the size of the buffer in bits
+	BitSize uint64
 }


### PR DESCRIPTION
Noticed this unnecessary allocation in DeltaContext's writeUnpacked/readUnpacked and removed it. 
It was already done in the same fashion in other DeltaContext functions.

![image](https://github.com/user-attachments/assets/adf3fae6-0491-4e86-b77d-378c22aa6115)


Also, tweaked some fieldalignments of integrated ztypes because why not ;-)
```
go-zserio/ztype/array.go:11:38: struct with 80 pointer bytes could be 48
go-zserio/ztype/bytes.go:4:16: struct with 16 pointer bytes could be 8
go-zserio/ztype/delta_context.go:16:26: struct of size 56 could be 48
go-zserio/ztype/extern.go:4:17: struct with 16 pointer bytes could be 8
```

The program was tested solely for our own use cases, which might differ from yours.

Jochen Mehlhorn <jochen.mehlhorn@mercedes-benz.com>, Mercedes-Benz Tech Innovation GmbH

[Provider Information](https://github.com/Daimler/daimler-foss/blob/master/PROVIDER_INFORMATION.md)