### PR TITLE
Avoid memory allocations for ArrayTraits

### DIFF
--- a/internal/generator/templates/array_init.go.tmpl
+++ b/internal/generator/templates/array_init.go.tmpl
@@ -5,8 +5,11 @@
 {{- $native := .native }}
 {{- $traits := goArrayTraits $scope $native.Type }}
 {{ $field.Name }}ArrayProperties := ztype.Array[{{if $native.IsMarshaler }}*{{ end }}{{ goType $scope $native.Type }}, {{ template "array_traits_type.go.tmpl" dict "pkg" $scope "type" $native.Type }}]{}
-{{ $field.Name }}ArrayProperties.ArrayTraits = {{ template "instantiate_array_traits.go.tmpl" dict "pkg" $scope "type" $native.Type }}
-
+{{ if or (eq $traits "ztype.ObjectArrayTraits") -}}
+    {{ $field.Name }}ArrayProperties.ArrayTraits = {{ template "instantiate_array_traits.go.tmpl" dict "pkg" $scope "type" $native.Type }}
+{{- else }}
+    {{ $field.Name }}ArrayProperties.ArrayTraits = *{{ template "instantiate_array_traits.go.tmpl" dict "pkg" $scope "type" $native.Type }}
+{{- end }}
 {{- if $field.Array.IsPacked }}
     {{ $field.Name }}ArrayProperties.IsPacked = true
 {{- end }}

--- a/internal/generator/templates/bitmask.go.tmpl
+++ b/internal/generator/templates/bitmask.go.tmpl
@@ -87,7 +87,7 @@ func (v *{{ $bitmask.Name}}) ZserioInitPackingContext(contextNode *zserio.Packin
   }
 
   traits := {{- template "instantiate_array_traits.go.tmpl" dict "pkg" $scope "type" $native.Type }}
-  context.Init(&traits, {{ goType $scope $native.Type }}(*v))
+  context.Init(traits, {{ goType $scope $native.Type }}(*v))
   return nil
 }
 
@@ -98,7 +98,7 @@ func (v *{{ $bitmask.Name}}) UnmarshalZserioPacked(contextNode *zserio.PackingCo
   }
 
   traits := {{- template "instantiate_array_traits.go.tmpl" dict "pkg" $scope "type" $native.Type }}
-  if tempValue, err := context.Read(&traits, r); err != nil {
+  if tempValue, err := context.Read(traits, r); err != nil {
     return err
   } else {
     (*v) = {{ $bitmask.Name }}(tempValue)
@@ -113,7 +113,7 @@ func (v *{{ $bitmask.Name}}) MarshalZserioPacked(contextNode *zserio.PackingCont
   }
 
   traits := {{- template "instantiate_array_traits.go.tmpl" dict "pkg" $scope "type" $native.Type }}
-  return context.Write(&traits, w, {{ goType $scope $native.Type }}(*v))
+  return context.Write(traits, w, {{ goType $scope $native.Type }}(*v))
 }
 
 func (v *{{ $bitmask.Name}}) ZserioInitializeOffsetsPacked(contextNode *zserio.PackingContextNode, bitPosition int) int {
@@ -125,7 +125,7 @@ func (v *{{ $bitmask.Name}}) ZserioBitSizePacked(contextNode *zserio.PackingCont
   if !ok {
       return 0, errors.New("invalid packing context")
   }
-  delta, err := context.BitSizeOf(&{{ template "instantiate_array_traits.go.tmpl" dict "pkg" $scope "type" $native.Type }}, bitPosition, {{ goType $scope $native.Type }}(*v))
+  delta, err := context.BitSizeOf({{ template "instantiate_array_traits.go.tmpl" dict "pkg" $scope "type" $native.Type }}, bitPosition, {{ goType $scope $native.Type }}(*v))
   if err != nil {
       return 0, err
   }

--- a/internal/generator/templates/enum.go.tmpl
+++ b/internal/generator/templates/enum.go.tmpl
@@ -176,7 +176,7 @@ func (v *{{ $enum.Name}}) ZserioInitPackingContext(contextNode *zserio.PackingCo
   }
 
   traits := {{- template "instantiate_array_traits.go.tmpl" dict "pkg" $scope "type" $native.Type }}
-  context.Init(&traits, {{ goType $scope $native.Type }}(*v))
+  context.Init(traits, {{ goType $scope $native.Type }}(*v))
   return nil
 }
 
@@ -188,7 +188,7 @@ func (v *{{ $enum.Name}}) UnmarshalZserioPacked(contextNode *zserio.PackingConte
   }
 
   traits := {{- template "instantiate_array_traits.go.tmpl" dict "pkg" $scope "type" $native.Type }}
-  if tempValue, err := context.Read(&traits, r); err != nil {
+  if tempValue, err := context.Read(traits, r); err != nil {
     return err
   } else {
     (*v) = {{ $enum.Name }}(tempValue)
@@ -203,7 +203,7 @@ func (v *{{ $enum.Name}}) MarshalZserioPacked(contextNode *zserio.PackingContext
   }
 
   traits := {{- template "instantiate_array_traits.go.tmpl" dict "pkg" $scope "type" $native.Type }}
-  return context.Write(&traits, w, {{ goType $scope $native.Type }}(*v))
+  return context.Write(traits, w, {{ goType $scope $native.Type }}(*v))
 }
 
 func (v *{{ $enum.Name}}) ZserioInitializeOffsetsPacked(contextNode *zserio.PackingContextNode, bitPosition int) int {
@@ -215,7 +215,7 @@ func (v *{{ $enum.Name}}) ZserioBitSizePacked(contextNode *zserio.PackingContext
   if !ok {
       return 0, errors.New("invalid packing context")
   }
-  delta, err := context.BitSizeOf(&{{ template "instantiate_array_traits.go.tmpl" dict "pkg" $scope "type" $native.Type }}, bitPosition, {{ goType $scope $native.Type }}(*v))
+  delta, err := context.BitSizeOf({{ template "instantiate_array_traits.go.tmpl" dict "pkg" $scope "type" $native.Type }}, bitPosition, {{ goType $scope $native.Type }}(*v))
   if err != nil {
       return 0, err
   }

--- a/internal/generator/templates/instantiate_array_traits.go.tmpl
+++ b/internal/generator/templates/instantiate_array_traits.go.tmpl
@@ -1,22 +1,41 @@
 {{- $scope := .pkg }}
 {{- $type := .type }}
 {{- $traits := goArrayTraits $scope $type }}
-{{- template "array_traits_type.go.tmpl" dict "pkg" $scope "type" $type }} {
 {{- if or (eq $traits "ztype.BitFieldArrayTraits") (eq $traits "ztype.SignedBitFieldArrayTraits") -}}
-    NumBits: uint8(
-    {{- if gt $type.Bits 0 }}
-        {{- $type.Bits }}
-    {{- else if $type.LengthExpression }}
-        {{- goExpression $scope $type.LengthExpression }}
-    {{- else if eq $type.Name "uint8" }}8
-    {{- else if eq $type.Name "uint16" }}16
-    {{- else if eq $type.Name "uint32" }}32
-    {{- else if eq $type.Name "uint64" }}64
-    {{- else if eq $type.Name "int8" }}8
-    {{- else if eq $type.Name "int16" }}16
-    {{- else if eq $type.Name "int32" }}32
-    {{- else if eq $type.Name "int64" }}64
+    {{- if gt $type.Bits 0 -}}
+        ztype.Get{{if eq $traits "ztype.SignedBitFieldArrayTraits" }}Signed{{ end }}BitFieldArrayTraits[{{ goType $scope $type }}](uint8({{- $type.Bits }}))
+    {{- else if $type.LengthExpression -}}
+        ztype.Get{{if eq $traits "ztype.SignedBitFieldArrayTraits" }}Signed{{ end }}BitFieldArrayTraits[{{ goType $scope $type }}](uint8({{- goExpression $scope $type.LengthExpression }}))
+    {{- else if eq $type.Name "uint8" }}ztype.ArrayTraits.UInt8
+    {{- else if eq $type.Name "uint16" }}ztype.ArrayTraits.UInt16
+    {{- else if eq $type.Name "uint32" }}ztype.ArrayTraits.UInt32
+    {{- else if eq $type.Name "uint64" }}ztype.ArrayTraits.UInt64
+    {{- else if eq $type.Name "int8" }}ztype.ArrayTraits.Int8
+    {{- else if eq $type.Name "int16" }}ztype.ArrayTraits.Int16
+    {{- else if eq $type.Name "int32" }}ztype.ArrayTraits.Int32
+    {{- else if eq $type.Name "int64" }}ztype.ArrayTraits.Int64
     {{- else }}UNSUPPORTED
-    {{- end }})
+    {{- end }}
+{{- else if eq $traits "ztype.ObjectArrayTraits" }}
+    {{- $traits }}[*{{ goType $scope $type }}]{}
+{{- else }}
+    {{- if eq $type.Name "varint" }}ztype.ArrayTraits.VarInt
+    {{- else if eq $type.Name "varint16" }}ztype.ArrayTraits.VarInt16
+    {{- else if eq $type.Name "varint32" }}ztype.ArrayTraits.VarInt32
+    {{- else if eq $type.Name "varint64" }}ztype.ArrayTraits.VarInt64
+    {{- else if eq $type.Name "varuint" }}ztype.ArrayTraits.VarUInt
+    {{- else if eq $type.Name "varuint16" }}ztype.ArrayTraits.VarUInt16
+    {{- else if eq $type.Name "varuint32" }}ztype.ArrayTraits.VarUInt32
+    {{- else if eq $type.Name "varuint64" }}ztype.ArrayTraits.VarUInt64
+    {{- else if eq $type.Name "varsize" }}ztype.ArrayTraits.VarSize
+    {{- else if eq $type.Name "bool" }}ztype.ArrayTraits.Bool
+    {{- else if eq $type.Name "string" }}ztype.ArrayTraits.String
+    {{- else if eq $type.Name "float16" }}ztype.ArrayTraits.Float16
+    {{- else if eq $type.Name "float32" }}ztype.ArrayTraits.Float32
+    {{- else if eq $type.Name "float64" }}ztype.ArrayTraits.Float64
+    {{- else if eq $type.Name "bytes" }}ztype.ArrayTraits.Bytes
+    {{- else if eq $type.Name "extern" }}ztype.ArrayTraits.Extern
+    {{- else }}UNSUPPORTED
+    {{- end }}
 {{- end -}}
-}{{/* remove trailing newlines */ -}}
+{{/* remove trailing newlines */ -}}

--- a/internal/generator/templates/packing_context_bitsize.go.tmpl
+++ b/internal/generator/templates/packing_context_bitsize.go.tmpl
@@ -56,7 +56,7 @@
     if field{{ $field.Name }}Context, ok := childrenNodes[{{ $index }}].Context.(*ztype.DeltaContext[{{ goType $scope $native.Type }}]); !ok {
         return 0, errors.New("invalid packing context")
     } else {
-        if delta, err := field{{ $field.Name }}Context.BitSizeOf(&{{ template "instantiate_array_traits.go.tmpl" dict "pkg" $scope "type" $native.Type }}, endBitPosition, {{ goType $scope $native.Type }}({{ $field_name }})); err != nil {
+        if delta, err := field{{ $field.Name }}Context.BitSizeOf({{ template "instantiate_array_traits.go.tmpl" dict "pkg" $scope "type" $native.Type }}, endBitPosition, {{ goType $scope $native.Type }}({{ $field_name }})); err != nil {
             return 0, err
         } else {
             endBitPosition += delta

--- a/internal/generator/templates/packing_context_decode.go.tmpl
+++ b/internal/generator/templates/packing_context_decode.go.tmpl
@@ -85,7 +85,7 @@
         return errors.New("unknown context type")
     } else {
         traits := {{ template "instantiate_array_traits.go.tmpl" dict "pkg" $scope "type" $native.Type }}
-        if tempValue, err := field{{ $field.Name }}Context.Read(&traits, r); err == nil {
+        if tempValue, err := field{{ $field.Name }}Context.Read(traits, r); err == nil {
             {{ $assign_str_lvalue }} = ({{ goType $scope $field.Type }})(tempValue)
         } else {
             return err

--- a/internal/generator/templates/packing_context_encode.go.tmpl
+++ b/internal/generator/templates/packing_context_encode.go.tmpl
@@ -78,7 +78,7 @@
     if field{{ $field.Name }}Context, ok := childrenNodes[{{ $index }}].Context.(*ztype.DeltaContext[{{ goType $scope $native.Type }}]); !ok {
         return errors.New("unknown context type")
     } else {
-        if err := field{{ $field.Name }}Context.Write(&{{ template "instantiate_array_traits.go.tmpl" dict "pkg" $scope "type" $native.Type }}, w, {{ goType $scope $native.Type }}({{ $field_name }})); err != nil {
+        if err := field{{ $field.Name }}Context.Write({{ template "instantiate_array_traits.go.tmpl" dict "pkg" $scope "type" $native.Type }}, w, {{ goType $scope $native.Type }}({{ $field_name }})); err != nil {
             return err
         }
     }

--- a/internal/generator/templates/packing_context_init.go.tmpl
+++ b/internal/generator/templates/packing_context_init.go.tmpl
@@ -35,9 +35,8 @@
         if field{{ $field.Name }}Context, ok := childrenNodes[{{ $index }}].Context.(*ztype.DeltaContext[{{ goType $scope $native.Type }}]); !ok {
             return errors.New("unknown context type")
         } else {
-
             traits := {{ template "instantiate_array_traits.go.tmpl" dict "pkg" $scope "type" $native.Type }}
-            field{{ $field.Name }}Context.Init(&traits, {{ goType $scope $native.Type }}({{ $field_name }}))
+            field{{ $field.Name }}Context.Init(traits, {{ goType $scope $native.Type }}({{ $field_name }}))
         }
     {{- end }}
 

--- a/ztype/array_traits.go
+++ b/ztype/array_traits.go
@@ -48,6 +48,85 @@ type IArrayTraits[T any] interface {
 	FromUint64(value uint64) T
 }
 
+var ArrayTraits = staticArrayTraits{
+	VarInt:    &VarIntArrayTraits{},
+	VarInt16:  &VarInt16ArrayTraits{},
+	VarInt32:  &VarInt32ArrayTraits{},
+	VarInt64:  &VarInt64ArrayTraits{},
+	VarUInt:   &VarUIntArrayTraits{},
+	VarUInt16: &VarUInt16ArrayTraits{},
+	VarUInt32: &VarUInt32ArrayTraits{},
+	VarUInt64: &VarUInt64ArrayTraits{},
+	VarSize:   &VarSizeArrayTraits{},
+	Bool:      &BooleanArrayTraits{},
+	String:    &StringArrayTraits{},
+	Float16:   &Float16ArrayTraits{},
+	Float32:   &Float32ArrayTraits{},
+	Float64:   &Float64ArrayTraits{},
+	Bytes:     &BytesArrayTraits{},
+	Extern:    &BitBufferArrayTraits{},
+	UInt8:     &BitFieldArrayTraits[uint8]{NumBits: 8},
+	UInt16:    &BitFieldArrayTraits[uint16]{NumBits: 16},
+	UInt32:    &BitFieldArrayTraits[uint32]{NumBits: 32},
+	UInt64:    &BitFieldArrayTraits[uint64]{NumBits: 64},
+	Int8:      &SignedBitFieldArrayTraits[int8]{NumBits: 8},
+	Int16:     &SignedBitFieldArrayTraits[int16]{NumBits: 16},
+	Int32:     &SignedBitFieldArrayTraits[int32]{NumBits: 32},
+	Int64:     &SignedBitFieldArrayTraits[int64]{NumBits: 64},
+}
+
+type staticArrayTraits struct {
+	VarInt    *VarIntArrayTraits
+	VarInt16  *VarInt16ArrayTraits
+	VarInt32  *VarInt32ArrayTraits
+	VarInt64  *VarInt64ArrayTraits
+	VarUInt   *VarUIntArrayTraits
+	VarUInt16 *VarUInt16ArrayTraits
+	VarUInt32 *VarUInt32ArrayTraits
+	VarUInt64 *VarUInt64ArrayTraits
+	VarSize   *VarSizeArrayTraits
+	Bool      *BooleanArrayTraits
+	String    *StringArrayTraits
+	Float16   *Float16ArrayTraits
+	Float32   *Float32ArrayTraits
+	Float64   *Float64ArrayTraits
+	Bytes     *BytesArrayTraits
+	Extern    *BitBufferArrayTraits
+	UInt8     *BitFieldArrayTraits[uint8]
+	UInt16    *BitFieldArrayTraits[uint16]
+	UInt32    *BitFieldArrayTraits[uint32]
+	UInt64    *BitFieldArrayTraits[uint64]
+	Int8      *SignedBitFieldArrayTraits[int8]
+	Int16     *SignedBitFieldArrayTraits[int16]
+	Int32     *SignedBitFieldArrayTraits[int32]
+	Int64     *SignedBitFieldArrayTraits[int64]
+}
+
+var (
+	mapSignedBitFieldArrayTraits []any = make([]any, 64)
+	mapBitFieldArrayTraits       []any = make([]any, 64)
+)
+
+func GetSignedBitFieldArrayTraits[T constraints.Signed](numBits uint8) *SignedBitFieldArrayTraits[T] {
+	traits := mapSignedBitFieldArrayTraits[numBits]
+	if traits == nil {
+		traits = &SignedBitFieldArrayTraits[T]{NumBits: uint8(numBits)}
+		mapSignedBitFieldArrayTraits[numBits] = traits
+	}
+
+	return traits.(*SignedBitFieldArrayTraits[T])
+}
+
+func GetBitFieldArrayTraits[T constraints.Unsigned](numBits uint8) *BitFieldArrayTraits[T] {
+	traits := mapBitFieldArrayTraits[numBits]
+	if traits == nil {
+		traits = &BitFieldArrayTraits[T]{NumBits: uint8(numBits)}
+		mapBitFieldArrayTraits[numBits] = traits
+	}
+
+	return traits.(*BitFieldArrayTraits[T])
+}
+
 // Float16ArrayTraits is an array trait implementation for float16 arrays.
 type Float16ArrayTraits struct{}
 
@@ -186,8 +265,7 @@ func (trait Float64ArrayTraits) FromUint64(value uint64) float64 {
 }
 
 // VarIntArrayTraits is an array traits implementation for VarInt.
-type VarIntArrayTraits struct {
-}
+type VarIntArrayTraits struct{}
 
 func (trait VarIntArrayTraits) PackedTraits() IPackedArrayTraits[int64] {
 	return &PackedArrayTraits[int64, VarIntArrayTraits]{
@@ -237,8 +315,7 @@ func (trait VarIntArrayTraits) FromUint64(value uint64) int64 {
 }
 
 // VarInt16ArrayTraits is the implementation of an array traits for a VarInt16.
-type VarInt16ArrayTraits struct {
-}
+type VarInt16ArrayTraits struct{}
 
 func (trait VarInt16ArrayTraits) PackedTraits() IPackedArrayTraits[int16] {
 	return &PackedArrayTraits[int16, VarInt16ArrayTraits]{
@@ -284,8 +361,7 @@ func (trait VarInt16ArrayTraits) FromUint64(value uint64) int16 {
 }
 
 // VarInt32ArrayTraits is the implementation of an array traits for a VarInt32.
-type VarInt32ArrayTraits struct {
-}
+type VarInt32ArrayTraits struct{}
 
 func (trait VarInt32ArrayTraits) PackedTraits() IPackedArrayTraits[int32] {
 	return &PackedArrayTraits[int32, VarInt32ArrayTraits]{
@@ -331,8 +407,7 @@ func (trait VarInt32ArrayTraits) FromUint64(value uint64) int32 {
 }
 
 // VarInt64ArrayTraits is the implementation of an array traits for a VarInt64.
-type VarInt64ArrayTraits struct {
-}
+type VarInt64ArrayTraits struct{}
 
 func (trait VarInt64ArrayTraits) PackedTraits() IPackedArrayTraits[int64] {
 	return &PackedArrayTraits[int64, VarInt64ArrayTraits]{
@@ -378,8 +453,7 @@ func (trait VarInt64ArrayTraits) FromUint64(value uint64) int64 {
 }
 
 // VarUInt16ArrayTraits is the implementation of an array traits for a VarUint16.
-type VarUInt16ArrayTraits struct {
-}
+type VarUInt16ArrayTraits struct{}
 
 func (trait VarUInt16ArrayTraits) PackedTraits() IPackedArrayTraits[uint16] {
 	return &PackedArrayTraits[uint16, VarUInt16ArrayTraits]{
@@ -424,8 +498,7 @@ func (trait VarUInt16ArrayTraits) FromUint64(value uint64) uint16 {
 	return uint16(value)
 }
 
-type VarUInt32ArrayTraits struct {
-}
+type VarUInt32ArrayTraits struct{}
 
 func (trait VarUInt32ArrayTraits) PackedTraits() IPackedArrayTraits[uint32] {
 	return &PackedArrayTraits[uint32, VarUInt32ArrayTraits]{
@@ -470,8 +543,7 @@ func (trait VarUInt32ArrayTraits) FromUint64(value uint64) uint32 {
 	return uint32(value)
 }
 
-type VarUInt64ArrayTraits struct {
-}
+type VarUInt64ArrayTraits struct{}
 
 func (trait VarUInt64ArrayTraits) PackedTraits() IPackedArrayTraits[uint64] {
 	return &PackedArrayTraits[uint64, VarUInt64ArrayTraits]{


### PR DESCRIPTION
Hi there,

as mentioned in #156 here is another PR that aims to reduce memory allocations during encoding/decoding.

When handling packed arrays, the structs' functions always create certain ArrayTraits structs that implement how binary data should be written or read. These struct instances cause memory allocations as they are handed in via pointer.

My implementation avoids repeated allocations by reusing these arraytrait structs. 


```
old
[...]
traits := ztype.SignedBitFieldArrayTraits[int64]{NumBits: uint8((uint8(31) - uint8(v.Shift)) + uint8(1))}
fieldLongitudeContext.Init(&traits, int64(v.Longitude))
[...]

new:
[...]
traits := ztype.GetSignedBitFieldArrayTraits[int64](uint8((uint8(31) - uint8(v.Shift)) + uint8(1)))
fieldLongitudeContext.Init(traits, int64(v.Longitude))
[...]
```

In my scenario, this alone brings down memory allocations 35% during decoding of DisplayLayer tiles (compared to go-zserio master). In combination with #156  allocations go down 65%.

I guess there are more elegant way to achieve this, but its a first attempt. 
I would've liked to directly integrate the arraytraits into the DeltaContext, but the usage of interfaces and generics is rather complicated for examples like the one above where the number of bits is dynamically calculated.

Bazel unit tests still work.

What do you think?

Cheers
Jochen


The program was tested solely for our own use cases, which might differ from yours.

Jochen Mehlhorn <jochen.mehlhorn@mercedes-benz.com>, Mercedes-Benz Tech Innovation GmbH

[Provider Information](https://github.com/Daimler/daimler-foss/blob/master/PROVIDER_INFORMATION.md)



